### PR TITLE
修复 TestPool Test 不稳定的问题

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -8,3 +8,4 @@
 [ekit: 实现了 LinkedList Get](https://github.com/gotomicro/ekit/pull/31)
 [ekit: 实现了 LinkedList Append](https://github.com/gotomicro/ekit/pull/34)
 [ekit: 实现了 LinkedList Delete](https://github.com/gotomicro/ekit/pull/38)
+[ekit: 修复 Pool TestPool](https://github.com/gotomicro/ekit/pull/40)

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -22,7 +22,9 @@ import (
 )
 
 func TestPool(t *testing.T) {
+	cnt := 0
 	p := New[[]byte](func() []byte {
+		cnt += 1
 		res := make([]byte, 1, 12)
 		res[0] = 'A'
 		return res
@@ -33,7 +35,12 @@ func TestPool(t *testing.T) {
 	res = append(res, 'B')
 	p.Put(res)
 	res = p.Get()
-	assert.Equal(t, "AB", string(res))
+	if cnt == 1 {
+		assert.Equal(t, "AB", string(res))
+	} else {
+		assert.Equal(t, "A", string(res))
+	}
+
 }
 
 func ExampleNew() {


### PR DESCRIPTION
会有偶发的不通过, 原因应该是, 执行第二次 get 之前, 发生了 gc.

- 加了一个 次数, 记录函数执行了几次
- 根据次数, 来判断应该取到什么值