### PR TITLE
slice: 重构 index 和 contains 的方法，直接调用对应Func 版本

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -1,5 +1,5 @@
 # 开发中
-
+- [slice: 重构 index 和 contains 的方法，直接调用对应Func 版本](https://github.com/gotomicro/ekit/pull/87)
 # v0.0.3
 - [ekit: add ToPtr function](https://github.com/gotomicro/ekit/pull/6)
 - [sqlx: 支持 JsonColumn](https://github.com/gotomicro/ekit/pull/7)

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,39 @@
+# Copyright 2021 gotomicro
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: 95%
+        threshold: 0.5%
+        # advanced settings
+        branches:
+          - main
+          - dev
+        if_ci_failed: error #success, failure, error, ignore
+        informational: false
+        only_pulls: false
+    patch:
+      default:
+        # basic
+        target: 95%
+        threshold: 0.5%
+        branches:
+          - main
+          - dev
+        if_ci_failed: error #success, failure, error, ignore
+        informational: false
+        only_pulls: false

--- a/slice/contains.go
+++ b/slice/contains.go
@@ -16,12 +16,9 @@ package slice
 
 // Contains 判断 src 里面是否存在 dst
 func Contains[T comparable](src []T, dst T) bool {
-	for _, v := range src {
-		if v == dst {
-			return true
-		}
-	}
-	return false
+	return ContainsFunc[T](src, dst, func(src, dst T) bool {
+		return src == dst
+	})
 }
 
 // ContainsFunc 判断 src 里面是否存在 dst

--- a/slice/diff_test.go
+++ b/slice/diff_test.go
@@ -16,7 +16,6 @@ package slice
 
 import (
 	"fmt"
-	"log"
 	"sort"
 	"testing"
 
@@ -58,7 +57,7 @@ func TestDiffSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res := DiffSet[int](tt.src, tt.dst)
-			assert.True(t, equal[int](res, tt.want))
+			assert.ElementsMatch(t, tt.want, res)
 		})
 	}
 }
@@ -100,25 +99,9 @@ func TestDiffSetFunc(t *testing.T) {
 			res := DiffSetFunc[int](tt.src, tt.dst, func(src, dst int) bool {
 				return src == dst
 			})
-			assert.True(t, equal[int](res, tt.want))
+			assert.ElementsMatch(t, tt.want, res)
 		})
 	}
-}
-
-func equal[T comparable](src, want []T) bool {
-	if len(src) == len(want) {
-		srcMap, wantMap := toIndexesMap[T](src), toIndexesMap[T](want)
-		for k, v := range wantMap {
-			if indexes, exist := srcMap[k]; !exist || len(indexes) != len(v) {
-				log.Printf("测试失败:\nactual:%v\nexpected:%v\n", src, want)
-				return false
-			}
-		}
-	} else {
-		log.Printf("测试失败:\nactual:%v\nexpected:%v\n", src, want)
-		return false
-	}
-	return true
 }
 
 func ExampleDiffSet() {

--- a/slice/index.go
+++ b/slice/index.go
@@ -17,12 +17,9 @@ package slice
 // Index 返回和 dst 相等的第一个元素下标
 // -1 表示没找到
 func Index[T comparable](src []T, dst T) int {
-	for i, val := range src {
-		if val == dst {
-			return i
-		}
-	}
-	return -1
+	return IndexFunc[T](src, dst, func(src, dst T) bool {
+		return src == dst
+	})
 }
 
 // IndexFunc 返回和 dst 相等的第一个元素下标
@@ -40,12 +37,9 @@ func IndexFunc[T any](src []T, dst T, equal equalFunc[T]) int {
 // LastIndex 返回和 dst 相等的最后一个元素下标
 // -1 表示没找到
 func LastIndex[T comparable](src []T, dst T) int {
-	for i := len(src) - 1; i >= 0; i-- {
-		if src[i] == dst {
-			return i
-		}
-	}
-	return -1
+	return LastIndexFunc[T](src, dst, func(src, dst T) bool {
+		return src == dst
+	})
 }
 
 // LastIndexFunc 返回和 dst 相等的最后一个元素下标
@@ -62,12 +56,9 @@ func LastIndexFunc[T any](src []T, dst T, equal equalFunc[T]) int {
 
 // IndexAll 返回和 dst 相等的所有元素的下标
 func IndexAll[T comparable](src []T, dst T) []int {
-	srcMap := toIndexesMap[T](src)
-	if indexes, exist := srcMap[dst]; exist {
-		return indexes
-	}
-	// 和 IndexAllFunc 保持语义
-	return []int{}
+	return IndexAllFunc[T](src, dst, func(src, dst T) bool {
+		return src == dst
+	})
 }
 
 // IndexAllFunc 返回和 dst 相等的所有元素的下标

--- a/slice/index_test.go
+++ b/slice/index_test.go
@@ -322,3 +322,27 @@ func ExampleIndexAllFunc() {
 	// [2 5]
 	// []
 }
+
+// BenchmarkIndex 主要是为了验证即便我们在 Index 这种方法里面直接调用 IndexFunc
+// 性能损失几乎没有。
+func BenchmarkIndex(b *testing.B) {
+	b.Run("loop directly", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			IndexByLoop[int]([]int{1, 2, 3, 4, 5, 6}, 5)
+		}
+	})
+	b.Run("delegate to IndexFunc", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			Index[int]([]int{1, 2, 3, 4, 5, 6}, 5)
+		}
+	})
+}
+
+func IndexByLoop[T comparable](src []T, dst T) int {
+	for i, val := range src {
+		if val == dst {
+			return i
+		}
+	}
+	return -1
+}

--- a/slice/index_test.go
+++ b/slice/index_test.go
@@ -231,7 +231,7 @@ func TestIndexAll(t *testing.T) {
 	}
 	for _, test := range tests {
 		res := IndexAll[int](test.src, test.dst)
-		assert.Equal(t, true, equal[int](res, test.want))
+		assert.ElementsMatch(t, test.want, res)
 	}
 }
 
@@ -271,7 +271,7 @@ func TestIndexAllFunc(t *testing.T) {
 		res := IndexAllFunc[int](test.src, test.dst, func(src, dst int) bool {
 			return src == dst
 		})
-		assert.Equal(t, true, equal[int](res, test.want))
+		assert.ElementsMatch(t, test.want, res)
 	}
 }
 

--- a/slice/intersect_test.go
+++ b/slice/intersect_test.go
@@ -74,7 +74,7 @@ func TestIntersectSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res := IntersectSet[int](tt.src, tt.dst)
-			assert.Equal(t, true, equal[int](res, tt.want))
+			assert.ElementsMatch(t, tt.want, res)
 		})
 	}
 }
@@ -133,7 +133,7 @@ func TestIntersectSetFunc(t *testing.T) {
 			res := IntersectSetFunc[int](tt.src, tt.dst, func(src, dst int) bool {
 				return src == dst
 			})
-			assert.Equal(t, true, equal[int](res, tt.want))
+			assert.ElementsMatch(t, tt.want, res)
 		})
 	}
 }

--- a/slice/map.go
+++ b/slice/map.go
@@ -32,14 +32,6 @@ func toMap[T comparable](src []T) map[T]struct{} {
 	return dataMap
 }
 
-func toIndexesMap[T comparable](src []T) map[T][]int {
-	var dataMap = make(map[T][]int, len(src))
-	for k, v := range src {
-		dataMap[v] = append(dataMap[v], k)
-	}
-	return dataMap
-}
-
 func deduplicateFunc[T any](data []T, equal equalFunc[T]) []T {
 	var newData = make([]T, 0, len(data))
 	for k, v := range data {

--- a/slice/symmetric_diff_test.go
+++ b/slice/symmetric_diff_test.go
@@ -60,7 +60,7 @@ func TestSymmetricDiffSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res := SymmetricDiffSet[int](tt.src, tt.dst)
-			assert.Equal(t, true, equal[int](res, tt.want))
+			assert.ElementsMatch(t, tt.want, res)
 		})
 	}
 }
@@ -105,7 +105,7 @@ func TestSymmetricDiffSetFunc(t *testing.T) {
 			res := SymmetricDiffSetFunc[int](tt.src, tt.dst, func(src, dst int) bool {
 				return src == dst
 			})
-			assert.Equal(t, true, equal[int](res, tt.want))
+			assert.ElementsMatch(t, tt.want, res)
 		})
 	}
 }

--- a/slice/union_test.go
+++ b/slice/union_test.go
@@ -58,7 +58,7 @@ func TestUnionSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res := UnionSet[int](tt.src, tt.dst)
-			assert.Equal(t, true, equal[int](res, tt.want))
+			assert.ElementsMatch(t, tt.want, res)
 		})
 	}
 }
@@ -101,7 +101,7 @@ func TestUnionSetFunc(t *testing.T) {
 			res := UnionSetFunc[int](tt.src, tt.dst, func(src, dst int) bool {
 				return src == dst
 			})
-			assert.Equal(t, true, equal[int](res, tt.want))
+			assert.ElementsMatch(t, tt.want, res)
 		})
 	}
 }


### PR DESCRIPTION
在 Index 和 Contains 里面的部分方法，我们可以直接调用 xxxFunc 的版本。

唯一的顾虑就是这种重构是否会引入性能的损失。为此我做了一个简单的基准测试来比较：
```go
func BenchmarkIndex(b *testing.B) {
	b.Run("loop directly", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			IndexByLoop[int]([]int{1, 2, 3, 4, 5, 6}, 5)
		}
	})
	b.Run("delegate to IndexFunc", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			Index[int]([]int{1, 2, 3, 4, 5, 6}, 5)
		}
	})
}

func IndexByLoop[T comparable](src []T, dst T) int {
	for i, val := range src {
		if val == dst {
			return i
		}
	}
	return -1
}
```
这里的 Index 方法已经被我改成了：
```go
func Index[T comparable](src []T, dst T) int {
	return IndexFunc[T](src, dst, func(src, dst T) bool {
		return src == dst
	})
}
```
也就是直接自己循环找，还是调用 IndexFunc 来找，两者进行一个性能比较。

在我的电脑上，运行效果是：
```go
pkg: github.com/gotomicro/ekit/slice
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkIndex/loop_directly-12                   100000                 3.654 ns/op           0 B/op          0 allocs/op
BenchmarkIndex/delegate_to_IndexFunc-12           100000                 3.534 ns/op           0 B/op          0 allocs/op
```
出乎预料的是，委托给 IndexFunc 反而要快一点。这是我无法解释的一个点，因为我最乐观的估计，就是编译器使用内联，那么两者也是性能相当，但是我每一次运行都是委托给 IndexFunc 更快