### PR TITLE
list: 优化 ArrayList Delete 的缩容逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # ekit
-泛型工具库
+泛型工具库。
+
+- [文档](https://ekit.gocn.vip/ekit/develop/guide/)

--- a/list/array_list_test.go
+++ b/list/array_list_test.go
@@ -318,6 +318,14 @@ func TestArrayList_Delete_Shrink(t *testing.T) {
 			wantCap: 2048,
 		},
 
+		// cap <= 64，但不满足缩容条件的例子
+		{
+			name:    "cap <= 64",
+			cap:     64,
+			loop:    2,
+			wantCap: 64,
+		},
+
 		// ----- #阶段二 边界测试# -----
 		// 测试用例边界
 		// ps:测试时：
@@ -329,14 +337,14 @@ func TestArrayList_Delete_Shrink(t *testing.T) {
 			name:    "case 6",
 			cap:     65,
 			loop:    2,
-			wantCap: 64,
+			wantCap: 32,
 		},
 		// case 6-2:  cap65,loop为16
 		{
 			name:    "case 6-2",
 			cap:     65,
 			loop:    16,
-			wantCap: 64,
+			wantCap: 32,
 		},
 		// case 6-3:  cap130,loop为34，删除一个元素后为33，刚好不满足四分之一
 		{


### PR DESCRIPTION
原本的缩容逻辑有一个问题：
假设说我现在的容量是 32，我的元素个数是 8，那么触发缩容的时候，我们反而会把容量设置为 64。

这个优化意味着容量在小于 64 的时候我们都不会处理。

64 算是一个经验值，32 也可以。基本理念都是在这种小容量下，已经没太大的必要去缩容了，引起不必要的 CPU 和新的内存分配开销