### PR TITLE
slice: FilterMap 和 Delete 方法

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -28,3 +28,4 @@
 - [syncx: 使用泛型封装 sync.Map](https://github.com/gotomicro/ekit/pull/79)
 - [slice: 支持 Diff*, Intersection*, Union*, Index* 类方法](https://github.com/gotomicro/ekit/pull/83)
 - [slice: 聚合函数 Max, Min 和 Sum](https://github.com/gotomicro/ekit/pull/82)
+- [slice: FilterMap 和 Delete 方法](https://github.com/gotomicro/ekit/pull/91)

--- a/internal/errs/error.go
+++ b/internal/errs/error.go
@@ -1,0 +1,22 @@
+// Copyright 2021 gotomicro
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errs
+
+import "fmt"
+
+// NewErrIndexOutOfRange 创建一个代表下标超出范围的错误
+func NewErrIndexOutOfRange(length int, index int) error {
+	return fmt.Errorf("ekit: 下标超出范围，长度 %d, 下标 %d", length, index)
+}

--- a/internal/slice/delete.go
+++ b/internal/slice/delete.go
@@ -1,0 +1,35 @@
+// Copyright 2021 gotomicro
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slice
+
+import "github.com/gotomicro/ekit/internal/errs"
+
+func Delete[T any](src []T, index int) ([]T, T, error) {
+	length := len(src)
+	if index < 0 || index >= length {
+		var zero T
+		return nil, zero, errs.NewErrIndexOutOfRange(length, index)
+	}
+	j := 0
+	res := src[index]
+	for i, v := range src {
+		if i != index {
+			src[j] = v
+			j++
+		}
+	}
+	src = src[:j]
+	return src, res, nil
+}

--- a/internal/slice/delete_test.go
+++ b/internal/slice/delete_test.go
@@ -1,0 +1,79 @@
+// Copyright 2021 gotomicro
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slice
+
+import (
+	"testing"
+
+	"github.com/gotomicro/ekit/internal/errs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDelete(t *testing.T) {
+	testCases := []struct {
+		name      string
+		slice     []int
+		index     int
+		wantSlice []int
+		wantVal   int
+		wantErr   error
+	}{
+		{
+			name:      "index 0",
+			slice:     []int{123, 100},
+			index:     0,
+			wantSlice: []int{100},
+			wantVal:   123,
+		},
+		{
+			name:      "index middle",
+			slice:     []int{123, 124, 125},
+			index:     1,
+			wantSlice: []int{123, 125},
+			wantVal:   124,
+		},
+		{
+			name:    "index out of range",
+			slice:   []int{123, 100},
+			index:   12,
+			wantErr: errs.NewErrIndexOutOfRange(2, 12),
+		},
+		{
+			name:    "index less than 0",
+			slice:   []int{123, 100},
+			index:   -1,
+			wantErr: errs.NewErrIndexOutOfRange(2, -1),
+		},
+		{
+			name:      "index last",
+			slice:     []int{123, 100, 101, 102, 102, 102},
+			index:     5,
+			wantSlice: []int{123, 100, 101, 102, 102},
+			wantVal:   102,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, val, err := Delete(tc.slice, tc.index)
+			assert.Equal(t, tc.wantErr, err)
+			if err != nil {
+				return
+			}
+			assert.Equal(t, tc.wantSlice, res)
+			assert.Equal(t, tc.wantVal, val)
+		})
+	}
+}

--- a/internal/slice/doc.go
+++ b/internal/slice/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2021 gotomicro
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package slice 后续逐步把切片会在不同部分使用的公共方法挪过来这个内部包
+package slice

--- a/list/array_list.go
+++ b/list/array_list.go
@@ -14,6 +14,11 @@
 
 package list
 
+import (
+	"github.com/gotomicro/ekit/internal/errs"
+	"github.com/gotomicro/ekit/internal/slice"
+)
+
 var (
 	_ List[any] = &ArrayList[any]{}
 )
@@ -38,7 +43,7 @@ func NewArrayListOf[T any](ts []T) *ArrayList[T] {
 func (a *ArrayList[T]) Get(index int) (t T, e error) {
 	l := a.Len()
 	if index < 0 || index >= l {
-		return t, newErrIndexOutOfRange(l, index)
+		return t, errs.NewErrIndexOutOfRange(l, index)
 	}
 	return a.vals[index], e
 }
@@ -53,7 +58,7 @@ func (a *ArrayList[T]) Append(ts ...T) error {
 // 当index等于ArrayList长度等同于append
 func (a *ArrayList[T]) Add(index int, t T) error {
 	if index < 0 || index > len(a.vals) {
-		return newErrIndexOutOfRange(len(a.vals), index)
+		return errs.NewErrIndexOutOfRange(len(a.vals), index)
 	}
 	a.vals = append(a.vals, t)
 	copy(a.vals[index+1:], a.vals[index:])
@@ -65,7 +70,7 @@ func (a *ArrayList[T]) Add(index int, t T) error {
 func (a *ArrayList[T]) Set(index int, t T) error {
 	length := len(a.vals)
 	if index >= length || index < 0 {
-		return newErrIndexOutOfRange(length, index)
+		return errs.NewErrIndexOutOfRange(length, index)
 	}
 	a.vals[index] = t
 	return nil
@@ -76,22 +81,13 @@ func (a *ArrayList[T]) Set(index int, t T) error {
 // - 如果容量 (64, 2048]，如果长度是容量的 1/4，那么就会缩容为原本的一半
 // - 如果此时容量 <= 64，那么我们将不会执行缩容。在容量很小的情况下，浪费的内存很少，所以没必要消耗 CPU去执行缩容
 func (a *ArrayList[T]) Delete(index int) (T, error) {
-	length := len(a.vals)
-	if index < 0 || index >= length {
-		var zero T
-		return zero, newErrIndexOutOfRange(length, index)
+	res, t, err := slice.Delete(a.vals, index)
+	if err != nil {
+		return t, err
 	}
-	j := 0
-	res := a.vals[index]
-	for i, v := range a.vals {
-		if i != index {
-			a.vals[j] = v
-			j++
-		}
-	}
-	a.vals = a.vals[:j]
+	a.vals = res
 	a.shrink()
-	return res, nil
+	return t, nil
 }
 
 // shrink 数组缩容
@@ -115,9 +111,6 @@ func (a *ArrayList[T]) shrink() {
 }
 
 func (a *ArrayList[T]) Len() int {
-	if a == nil {
-		return 0
-	}
 	return len(a.vals)
 }
 
@@ -136,7 +129,7 @@ func (a *ArrayList[T]) Range(fn func(index int, t T) error) error {
 }
 
 func (a *ArrayList[T]) AsSlice() []T {
-	slice := make([]T, len(a.vals))
-	copy(slice, a.vals)
-	return slice
+	res := make([]T, len(a.vals))
+	copy(res, a.vals)
+	return res
 }

--- a/list/array_list_test.go
+++ b/list/array_list_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gotomicro/ekit/internal/errs"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -213,16 +215,7 @@ func TestArrayList_Delete(t *testing.T) {
 		wantErr   error
 	}{
 		{
-			name: "index 0",
-			list: &ArrayList[int]{
-				vals: []int{123, 100},
-			},
-			index:     0,
-			wantSlice: []int{100},
-			wantVal:   123,
-		},
-		{
-			name: "index middle",
+			name: "deleted",
 			list: &ArrayList[int]{
 				vals: []int{123, 124, 125},
 			},
@@ -236,24 +229,7 @@ func TestArrayList_Delete(t *testing.T) {
 				vals: []int{123, 100},
 			},
 			index:   12,
-			wantErr: newErrIndexOutOfRange(2, 12),
-		},
-		{
-			name: "index less than 0",
-			list: &ArrayList[int]{
-				vals: []int{123, 100},
-			},
-			index:   -1,
-			wantErr: newErrIndexOutOfRange(2, -1),
-		},
-		{
-			name: "index last",
-			list: &ArrayList[int]{
-				vals: []int{123, 100, 101, 102, 102, 102},
-			},
-			index:     5,
-			wantSlice: []int{123, 100, 101, 102, 102},
-			wantVal:   102,
+			wantErr: errs.NewErrIndexOutOfRange(2, 12),
 		},
 	}
 

--- a/list/concurrent_list_test.go
+++ b/list/concurrent_list_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gotomicro/ekit/internal/errs"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -208,13 +210,13 @@ func TestConcurrentList_Delete(t *testing.T) {
 			name:    "index out of range",
 			list:    newConcurrentListOfSlice([]int{123, 100}),
 			index:   12,
-			wantErr: newErrIndexOutOfRange(2, 12),
+			wantErr: errs.NewErrIndexOutOfRange(2, 12),
 		},
 		{
 			name:    "index less than 0",
 			list:    newConcurrentListOfSlice([]int{123, 100}),
 			index:   -1,
-			wantErr: newErrIndexOutOfRange(2, -1),
+			wantErr: errs.NewErrIndexOutOfRange(2, -1),
 		},
 		{
 			name:      "index last",

--- a/list/linked_list.go
+++ b/list/linked_list.go
@@ -14,6 +14,8 @@
 
 package list
 
+import "github.com/gotomicro/ekit/internal/errs"
+
 var (
 	_ List[any] = &LinkedList[any]{}
 )
@@ -72,7 +74,7 @@ func (l *LinkedList[T]) findNode(index int) *node[T] {
 func (l *LinkedList[T]) Get(index int) (T, error) {
 	if !l.checkIndex(index) {
 		var zeroValue T
-		return zeroValue, newErrIndexOutOfRange(l.Len(), index)
+		return zeroValue, errs.NewErrIndexOutOfRange(l.Len(), index)
 	}
 	n := l.findNode(index)
 	return n.val, nil
@@ -96,7 +98,7 @@ func (l *LinkedList[T]) Append(ts ...T) error {
 // 当 index 等于 LinkedList 长度等同于 Append
 func (l *LinkedList[T]) Add(index int, t T) error {
 	if index < 0 || index > l.length {
-		return newErrIndexOutOfRange(l.length, index)
+		return errs.NewErrIndexOutOfRange(l.length, index)
 	}
 	if index == l.length {
 		return l.Append(t)
@@ -111,7 +113,7 @@ func (l *LinkedList[T]) Add(index int, t T) error {
 // Set 设置链表中index索引处的值为t
 func (l *LinkedList[T]) Set(index int, t T) error {
 	if !l.checkIndex(index) {
-		return newErrIndexOutOfRange(l.Len(), index)
+		return errs.NewErrIndexOutOfRange(l.Len(), index)
 	}
 	node := l.findNode(index)
 	node.val = t
@@ -122,7 +124,7 @@ func (l *LinkedList[T]) Set(index int, t T) error {
 func (l *LinkedList[T]) Delete(index int) (T, error) {
 	if !l.checkIndex(index) {
 		var zeroValue T
-		return zeroValue, newErrIndexOutOfRange(l.Len(), index)
+		return zeroValue, errs.NewErrIndexOutOfRange(l.Len(), index)
 	}
 	node := l.findNode(index)
 	node.prev.next = node.next

--- a/slice/delete.go
+++ b/slice/delete.go
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package list
+package slice
 
-import "fmt"
+import "github.com/gotomicro/ekit/internal/slice"
 
-// newErrIndexOutOfRange 创建一个代表
-func newErrIndexOutOfRange(length int, index int) error {
-	return fmt.Errorf("ekit: 下标超出范围，长度 %d, 下标 %d", length, index)
+// Delete 删除 index 处的元素
+func Delete[Src any](src []Src, index int) ([]Src, error) {
+	res, _, err := slice.Delete[Src](src, index)
+	return res, err
 }

--- a/slice/delete_test.go
+++ b/slice/delete_test.go
@@ -1,0 +1,69 @@
+// Copyright 2021 gotomicro
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slice
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gotomicro/ekit/internal/errs"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDelete(t *testing.T) {
+	// Delete 主要依赖于 internal/slice.Delete 来保证正确性
+	testCases := []struct {
+		name      string
+		slice     []int
+		index     int
+		wantSlice []int
+		wantErr   error
+	}{
+		{
+			name:      "index 0",
+			slice:     []int{123, 100},
+			index:     0,
+			wantSlice: []int{100},
+		},
+		{
+			name:    "index -1",
+			slice:   []int{123, 100},
+			index:   -1,
+			wantErr: errs.NewErrIndexOutOfRange(2, -1),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := Delete(tc.slice, tc.index)
+			assert.Equal(t, tc.wantErr, err)
+			if err != nil {
+				return
+			}
+			assert.Equal(t, tc.wantSlice, res)
+		})
+	}
+}
+
+func ExampleDelete() {
+	res, _ := Delete[int]([]int{1, 2, 3, 4}, 2)
+	fmt.Println(res)
+	_, err := Delete[int]([]int{1, 2, 3, 4}, -1)
+	fmt.Println(err)
+	// Output:
+	// [1 2 4]
+	// ekit: 下标超出范围，长度 4, 下标 -1
+}

--- a/slice/map.go
+++ b/slice/map.go
@@ -14,6 +14,20 @@
 
 package slice
 
+// FilterMap 执行过滤并且转化
+// 如果 m 的第二个返回值是 false，那么我们会忽略第一个返回值
+// 即便第二个返回值是 false，后续的元素依旧会被遍历
+func FilterMap[Src any, Dst any](src []Src, m func(idx int, src Src) (Dst, bool)) []Dst {
+	res := make([]Dst, 0, len(src))
+	for i, s := range src {
+		dst, ok := m(i, s)
+		if ok {
+			res = append(res, dst)
+		}
+	}
+	return res
+}
+
 func Map[Src any, Dst any](src []Src, m func(idx int, src Src) Dst) []Dst {
 	dst := make([]Dst, len(src))
 	for i, s := range src {

--- a/slice/map_test.go
+++ b/slice/map_test.go
@@ -61,3 +61,43 @@ func ExampleMap() {
 	fmt.Println(dst)
 	// Output: [1 2 3]
 }
+
+func TestFilterMap(t *testing.T) {
+	tests := []struct {
+		name string
+		src  []int
+		want []string
+	}{
+		{
+			name: "src nil",
+			want: []string{},
+		},
+		{
+			name: "src empty",
+			src:  []int{},
+			want: []string{},
+		},
+		{
+			name: "src has element",
+			src:  []int{1, -2, 3},
+			want: []string{"1", "3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := FilterMap(tt.src, func(idx int, src int) (string, bool) {
+				return strconv.Itoa(src), src >= 0
+			})
+			assert.Equal(t, res, tt.want)
+		})
+	}
+}
+
+func ExampleFilterMap() {
+	src := []int{1, -2, 3}
+	dst := FilterMap[int, string](src, func(idx int, src int) (string, bool) {
+		return strconv.Itoa(src), src >= 0
+	})
+	fmt.Println(dst)
+	// Output: [1 3]
+}


### PR DESCRIPTION
大多数时候，公共方法我都会设计 error 作为返回值。

Delete 也是如此。

虽然理论上我可以在下标超出范围的时候 panic 或者忽略，但是我认为这种决策应该是由用户来做的，我只需要如实禀告发生了什么。毕竟有些人可能喜欢 panic，有些人喜欢忽略。我不应该越俎代庖做决策。

同时，后续会逐步把公共逻辑迁移进去 internal 里面，包括 error 的创建最好都是通过 errs 包，后期我们引入错误码和错误排查手册的时候会更加方便一点。

我们也应该避免暴露 sentinel error，除非逼不得已