### PR TITLE
重构TaskPool实现 #80 中讨论的新需求

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -29,3 +29,4 @@
 - [slice: 支持 Diff*, Intersection*, Union*, Index* 类方法](https://github.com/gotomicro/ekit/pull/83)
 - [slice: 聚合函数 Max, Min 和 Sum](https://github.com/gotomicro/ekit/pull/82)
 - [slice: FilterMap 和 Delete 方法](https://github.com/gotomicro/ekit/pull/91)
+- [pool: 重构TaskPool](https://github.com/gotomicro/ekit/pull/93)

--- a/pool/task_pool_test.go
+++ b/pool/task_pool_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gotomicro/ekit/bean/option"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/errgroup"
 )
@@ -66,6 +67,84 @@ func TestOnDemandBlockTaskPool_In_Created_State(t *testing.T) {
 		pool, err = NewOnDemandBlockTaskPool(1, 1)
 		assert.NoError(t, err)
 		assert.NotNil(t, pool)
+
+		t.Run("With Options", func(t *testing.T) {
+			t.Parallel()
+
+			concurrency := 10
+			pool, err := NewOnDemandBlockTaskPool(concurrency, 10)
+			assert.NoError(t, err)
+
+			assert.Equal(t, int32(concurrency), pool.initGo)
+			assert.Equal(t, int32(concurrency), pool.coreGo)
+			assert.Equal(t, int32(concurrency), pool.maxGo)
+			assert.Equal(t, defaultMaxIdleTime, pool.maxIdleTime)
+
+			coreGo, maxGo, maxIdleTime := int32(20), int32(30), 10*time.Second
+			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime))
+			assert.NoError(t, err)
+
+			assert.Equal(t, int32(concurrency), pool.initGo)
+			assert.Equal(t, coreGo, pool.coreGo)
+			assert.Equal(t, maxGo, pool.maxGo)
+			assert.Equal(t, maxIdleTime, pool.maxIdleTime)
+
+			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo))
+			assert.NoError(t, err)
+			assert.Equal(t, pool.coreGo, pool.maxGo)
+
+			concurrency, coreGo = 30, 20
+			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo))
+			assert.Nil(t, pool)
+			assert.ErrorIs(t, err, errInvalidArgument)
+
+			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithMaxGo(maxGo))
+			assert.NoError(t, err)
+			assert.Equal(t, pool.maxGo, pool.coreGo)
+
+			concurrency, maxGo = 30, 10
+			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithMaxGo(maxGo))
+			assert.Nil(t, pool)
+			assert.ErrorIs(t, err, errInvalidArgument)
+
+			concurrency, coreGo, maxGo = 30, 20, 10
+			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
+			assert.Nil(t, pool)
+			assert.ErrorIs(t, err, errInvalidArgument)
+
+			concurrency, coreGo, maxGo = 30, 10, 20
+			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
+			assert.Nil(t, pool)
+			assert.ErrorIs(t, err, errInvalidArgument)
+
+			concurrency, coreGo, maxGo = 20, 10, 30
+			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
+			assert.Nil(t, pool)
+			assert.ErrorIs(t, err, errInvalidArgument)
+
+			concurrency, coreGo, maxGo = 20, 30, 10
+			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
+			assert.Nil(t, pool)
+			assert.ErrorIs(t, err, errInvalidArgument)
+
+			concurrency, coreGo, maxGo = 10, 30, 20
+			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
+			assert.Nil(t, pool)
+			assert.ErrorIs(t, err, errInvalidArgument)
+
+			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithQueueBacklogRate(-0.1))
+			assert.Nil(t, pool)
+			assert.ErrorIs(t, err, errInvalidArgument)
+
+			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithQueueBacklogRate(1.0))
+			assert.NotNil(t, pool)
+			assert.NoError(t, err)
+
+			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithQueueBacklogRate(1.1))
+			assert.Nil(t, pool)
+			assert.ErrorIs(t, err, errInvalidArgument)
+
+		})
 	})
 
 	// Start()导致TaskPool状态迁移，测试见TestTaskPool_In_Running_State/Start
@@ -186,6 +265,294 @@ func TestOnDemandBlockTaskPool_In_Running_State(t *testing.T) {
 	// Shutdown()导致TaskPool状态迁移，TestTaskPool_In_Closing_State/Shutdown
 
 	// ShutdownNow()导致TaskPool状态迁移，TestTestPool_In_Stopped_State/ShutdownNow
+
+	t.Run("工作协程", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("保持在初始数不变", func(t *testing.T) {
+			t.Parallel()
+
+			concurrency, queueSize := 1, 3
+			pool := testNewRunningStateTaskPool(t, concurrency, queueSize)
+
+			n := queueSize
+			done1 := make(chan struct{}, n)
+			wait := make(chan struct{}, n)
+
+			// 队列中有积压任务
+			for i := 0; i < n; i++ {
+				err := pool.Submit(context.Background(), TaskFunc(func(ctx context.Context) error {
+					wait <- struct{}{}
+					<-done1
+					return nil
+				}))
+				assert.NoError(t, err)
+			}
+
+			// concurrency个tasks在运行中
+			for i := 0; i < concurrency; i++ {
+				<-wait
+			}
+
+			assert.Equal(t, int32(concurrency), pool.numOfGo())
+
+			// 使运行中的tasks结束
+			for i := 0; i < concurrency; i++ {
+				done1 <- struct{}{}
+			}
+
+			// 积压在队列中的任务开始运行
+			for i := 0; i < n-concurrency; i++ {
+				<-wait
+				assert.Equal(t, int32(concurrency), pool.numOfGo())
+				done1 <- struct{}{}
+			}
+
+		})
+
+		t.Run("从初始数达到核心数", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("一次性全开", func(t *testing.T) {
+				t.Parallel()
+
+				t.Run("核心数比初始数多1个", func(t *testing.T) {
+					t.Parallel()
+
+					concurrency, coreGo, maxIdleTime := int32(1), int32(2), 3*time.Millisecond
+					queueSize := int(coreGo)
+					testExtendNumGoFromInitGoToCoreGoAtOnce(t, concurrency, queueSize, coreGo, maxIdleTime)
+				})
+
+				t.Run("核心数比初始数多n个", func(t *testing.T) {
+					t.Parallel()
+
+					concurrency, coreGo, maxIdleTime := int32(1), int32(3), 3*time.Millisecond
+					queueSize := int(coreGo)
+					testExtendNumGoFromInitGoToCoreGoAtOnce(t, concurrency, queueSize, coreGo, maxIdleTime)
+				})
+			})
+
+			t.Run("一次一个开", func(t *testing.T) {
+				t.Parallel()
+
+				t.Run("核心数比初始数多1个", func(t *testing.T) {
+					concurrency, coreGo, maxIdleTime, queueBacklogRate := int32(2), int32(3), 3*time.Millisecond, 0.1
+					queueSize := int(coreGo)
+					testExtendNumGoFromInitGoToCoreGoStepByStep(t, concurrency, queueSize, coreGo, maxIdleTime, WithQueueBacklogRate(queueBacklogRate))
+				})
+
+				t.Run("核心数比初始数多n个", func(t *testing.T) {
+					t.Parallel()
+
+					concurrency, coreGo, maxIdleTime, queueBacklogRate := int32(2), int32(5), 3*time.Millisecond, 0.1
+					queueSize := int(coreGo)
+					testExtendNumGoFromInitGoToCoreGoStepByStep(t, concurrency, queueSize, coreGo, maxIdleTime, WithQueueBacklogRate(queueBacklogRate))
+
+				})
+			})
+
+			t.Run("在(初始数,核心数]区间的协程运行完任务后，在等待退出期间再次抢到任务", func(t *testing.T) {
+				t.Parallel()
+
+				concurrency, coreGo, maxIdleTime := int32(1), int32(6), 100*time.Millisecond
+				queueSize := int(coreGo)
+
+				pool := testNewRunningStateTaskPool(t, int(concurrency), queueSize, WithCoreGo(coreGo), WithMaxIdleTime(maxIdleTime))
+				done := make(chan struct{}, queueSize)
+				wait := make(chan struct{}, queueSize)
+
+				for i := 0; i < queueSize; i++ {
+					// i := i
+					err := pool.Submit(context.Background(), TaskFunc(func(ctx context.Context) error {
+						wait <- struct{}{}
+						<-done
+						// t.Log("task done", i)
+						return nil
+					}))
+					assert.NoError(t, err)
+				}
+
+				for i := 0; i < queueSize; i++ {
+					<-wait
+				}
+				assert.Equal(t, coreGo, pool.numOfGo())
+
+				close(done)
+
+				err := pool.Submit(context.Background(), TaskFunc(func(ctx context.Context) error {
+					<-done
+					// t.Log("task done [x]")
+					return nil
+				}))
+				assert.NoError(t, err)
+
+				// <-time.After(maxIdleTime * 100)
+				for pool.numOfGo() > concurrency {
+					// t.Log("loop", "numOfGo", pool.numOfGo(), "timeoutGroup", pool.timeoutGroup.size())
+					time.Sleep(maxIdleTime)
+				}
+				assert.Equal(t, concurrency, pool.numOfGo())
+			})
+		})
+
+		t.Run("从核心数到达最大数", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("一次性全开", func(t *testing.T) {
+				t.Parallel()
+
+				t.Run("最大数比核心数多1个", func(t *testing.T) {
+					t.Parallel()
+
+					concurrency, coreGo, maxGo, maxIdleTime := int32(2), int32(4), int32(5), 3*time.Millisecond
+					queueSize := int(maxGo)
+					testExtendNumGoFromInitGoToCoreGoAndMaxGoAtOnce(t, concurrency, queueSize, coreGo, maxGo, maxIdleTime)
+				})
+
+				t.Run("最大数比核心数多n个", func(t *testing.T) {
+					t.Parallel()
+
+					concurrency, coreGo, maxGo, maxIdleTime := int32(2), int32(3), int32(5), 3*time.Millisecond
+					queueSize := int(maxGo)
+					testExtendNumGoFromInitGoToCoreGoAndMaxGoAtOnce(t, concurrency, queueSize, coreGo, maxGo, maxIdleTime)
+				})
+
+			})
+
+			t.Run("一次一个开", func(t *testing.T) {
+				t.Parallel()
+
+				t.Run("最大数比核心数多1个", func(t *testing.T) {
+					t.Parallel()
+
+					concurrency, coreGo, maxGo, maxIdleTime, queueBacklogRate := int32(2), int32(4), int32(5), 3*time.Millisecond, 0.1
+					queueSize := int(maxGo)
+					testExtendNumGoFromInitGoToCoreGoAndMaxGoStepByStep(t, concurrency, queueSize, coreGo, maxGo, maxIdleTime, WithQueueBacklogRate(queueBacklogRate))
+				})
+
+				t.Run("最大数比核心数多n个", func(t *testing.T) {
+					t.Parallel()
+
+					concurrency, coreGo, maxGo, maxIdleTime, queueBacklogRate := int32(1), int32(3), int32(6), 3*time.Millisecond, 0.1
+					queueSize := int(maxGo)
+					testExtendNumGoFromInitGoToCoreGoAndMaxGoStepByStep(t, concurrency, queueSize, coreGo, maxGo, maxIdleTime, WithQueueBacklogRate(queueBacklogRate))
+				})
+			})
+		})
+	})
+
+}
+
+type extendStrategyCheckFunc func(t *testing.T, i int32, pool *OnDemandBlockTaskPool)
+
+func testExtendNumGoFromInitGoToCoreGoAtOnce(t *testing.T, concurrency int32, queueSize int, coreGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
+	extendToCoreGoAtOnce := func(t *testing.T, i int32, pool *OnDemandBlockTaskPool) {
+		assert.Equal(t, coreGo, pool.numOfGo())
+	}
+	opts = append(opts, WithCoreGo(coreGo), WithMaxIdleTime(maxIdleTime))
+	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, coreGo, maxIdleTime, extendToCoreGoAtOnce, nil, opts...)
+}
+
+func testExtendNumGoFromInitGoToCoreGoStepByStep(t *testing.T, concurrency int32, queueSize int, coreGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
+	extendToCoreGoAtOnce := func(t *testing.T, i int32, pool *OnDemandBlockTaskPool) {
+		assert.Equal(t, i, pool.numOfGo())
+	}
+	opts = append(opts, WithCoreGo(coreGo), WithMaxIdleTime(maxIdleTime))
+	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, coreGo, maxIdleTime, extendToCoreGoAtOnce, nil, opts...)
+}
+
+func testExtendNumGoFromInitGoToCoreGoAndMaxGoAtOnce(t *testing.T, concurrency int32, queueSize int, coreGo int32, maxGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
+	extendToCoreGoAtOnce := func(t *testing.T, i int32, pool *OnDemandBlockTaskPool) {
+		assert.Equal(t, coreGo, pool.numOfGo())
+	}
+	extendToMaxGoAtOnce := func(t *testing.T, i int32, pool *OnDemandBlockTaskPool) {
+		assert.Equal(t, maxGo, pool.numOfGo())
+	}
+	opts = append(opts, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime))
+	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, maxGo, maxIdleTime, extendToCoreGoAtOnce, extendToMaxGoAtOnce, opts...)
+}
+
+func testExtendNumGoFromInitGoToCoreGoAndMaxGoStepByStep(t *testing.T, concurrency int32, queueSize int, coreGo, maxGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
+	extendStepByStep := func(t *testing.T, i int32, pool *OnDemandBlockTaskPool) {
+		assert.Equal(t, i, pool.numOfGo())
+	}
+	opts = append(opts, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime))
+	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, maxGo, maxIdleTime, extendStepByStep, extendStepByStep, opts...)
+}
+
+func testExtendNumGoFromInitGoToCoreGoAndMaxGo(t *testing.T, initGo int32, queueSize int, coreGo, maxGo int32, maxIdleTime time.Duration, duringExtendToCoreGo extendStrategyCheckFunc, duringExtendToMaxGo extendStrategyCheckFunc, opts ...option.Option[OnDemandBlockTaskPool]) {
+
+	pool := testNewRunningStateTaskPool(t, int(initGo), queueSize, opts...)
+	// waitTime := (maxIdleTime + 1) * 330
+
+	assert.LessOrEqual(t, initGo, coreGo)
+	assert.LessOrEqual(t, coreGo, maxGo)
+
+	done := make(chan struct{})
+	wait := make(chan struct{}, maxGo)
+
+	// 稳定在concurrency
+	for i := int32(0); i < initGo; i++ {
+		err := pool.Submit(context.Background(), TaskFunc(func(ctx context.Context) error {
+			wait <- struct{}{}
+			<-done
+			return nil
+		}))
+		assert.NoError(t, err)
+	}
+	// t.Log("AA")
+	for i := int32(0); i < initGo; i++ {
+		<-wait
+	}
+	assert.Equal(t, initGo, pool.numOfGo())
+	// t.Log("BB")
+
+	// 逐步添加任务
+	for i := int32(1); i <= coreGo-initGo; i++ {
+		err := pool.Submit(context.Background(), TaskFunc(func(ctx context.Context) error {
+			wait <- struct{}{}
+			<-done
+			return nil
+		}))
+		assert.NoError(t, err)
+		// t.Log("before wait", "m", m, "i", i, "m-n", m-n, "len(wait)", len(wait), "len(queue)", len(pool.queue), "numGO", pool.numOfGo(), "nextnumGO", pool.expectedNumGo)
+		<-wait
+		// t.Log("after wait coreGo", coreGo, i, pool.numOfGo())
+
+		duringExtendToCoreGo(t, i+initGo, pool)
+		// assert.Equal(t, i+n, pool.numOfGo())
+	}
+
+	// t.Log("CC")
+
+	assert.Equal(t, coreGo, pool.numOfGo())
+
+	for i := int32(1); i <= maxGo-coreGo; i++ {
+
+		err := pool.Submit(context.Background(), TaskFunc(func(ctx context.Context) error {
+			wait <- struct{}{}
+			<-done
+			return nil
+		}))
+		assert.NoError(t, err)
+		// t.Log("before wait", "m", m, "i", i, "m-n", m-n, "len(wait)", len(wait), "len(queue)", len(pool.queue), "numGO", pool.numOfGo(), "nextnumGO", pool.expectedNumGo)
+		<-wait
+		// t.Log("after wait maxGo", maxGo, i, pool.numOfGo())
+
+		duringExtendToMaxGo(t, i+coreGo, pool)
+	}
+
+	// t.Log("DD")
+
+	assert.Equal(t, maxGo, pool.numOfGo())
+	close(done)
+
+	// 等待最大空闲时间后，稳定在n
+	// <-time.After(waitTime)
+	for pool.numOfGo() > initGo {
+	}
+	assert.Equal(t, initGo, pool.numOfGo())
 }
 
 func TestOnDemandBlockTaskPool_In_Closing_State(t *testing.T) {
@@ -200,56 +567,88 @@ func TestOnDemandBlockTaskPool_In_Closing_State(t *testing.T) {
 		// 模拟阻塞提交
 		n := concurrency + queueSize*2
 		eg := new(errgroup.Group)
-		waitChan := make(chan struct{})
+		waitChan := make(chan struct{}, n)
+		taskDone := make(chan struct{})
 		for i := 0; i < n; i++ {
 			eg.Go(func() error {
 				return pool.Submit(context.Background(), TaskFunc(func(ctx context.Context) error {
-					<-waitChan
+					waitChan <- struct{}{}
+					<-taskDone
 					return nil
 				}))
 			})
 		}
-
-		// 调用Shutdown使TaskPool状态发生迁移
-		type ShutdownResult struct {
-			done <-chan struct{}
-			err  error
+		for i := 0; i < concurrency; i++ {
+			<-waitChan
 		}
-		resultChan := make(chan ShutdownResult)
-		go func() {
-			time.Sleep(100 * time.Millisecond)
-			done, err := pool.Shutdown()
-			resultChan <- ShutdownResult{done: done, err: err}
-		}()
-		r := <-resultChan
-
+		done, err := pool.Shutdown()
+		assert.NoError(t, err)
 		// Closing过程中Submit会报错间接证明TaskPool处于StateClosing状态
 		assert.ErrorIs(t, eg.Wait(), errTaskPoolIsClosing)
 
-		// Shutdown调用成功
-		assert.NoError(t, r.err)
-		select {
-		case <-r.done:
-			break
-		default:
-			// 第二次调用
-			done2, err2 := pool.Shutdown()
-			assert.Nil(t, done2)
-			assert.ErrorIs(t, err2, errTaskPoolIsClosing)
-			assert.Equal(t, stateClosing, pool.internalState())
-		}
+		// 第二次调用
+		done2, err2 := pool.Shutdown()
+		assert.Nil(t, done2)
+		assert.ErrorIs(t, err2, errTaskPoolIsClosing)
+		assert.Equal(t, stateClosing, pool.internalState())
 
-		assert.Equal(t, int32(concurrency), pool.NumGo())
+		assert.Equal(t, int32(concurrency), pool.numOfGo())
 
-		close(waitChan)
-		<-r.done
+		close(taskDone)
+		<-done
 		assert.Equal(t, stateStopped, pool.internalState())
 
 		// 第一个Shutdown将状态迁移至StateStopped
 		// 第三次调用
-		done, err := pool.Shutdown()
-		assert.Nil(t, done)
+		done3, err := pool.Shutdown()
+		assert.Nil(t, done3)
 		assert.ErrorIs(t, err, errTaskPoolIsStopped)
+	})
+
+	t.Run("Shutdown —— 协程数仍能按需扩展，调度循环也能自然退出", func(t *testing.T) {
+		t.Parallel()
+
+		concurrency, coreGo, maxGo, maxIdleTime, queueBacklogRate := int32(1), int32(3), int32(5), 10*time.Millisecond, 0.1
+		queueSize := int(maxGo)
+		pool := testNewRunningStateTaskPool(t, int(concurrency), queueSize, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime), WithQueueBacklogRate(queueBacklogRate))
+
+		assert.LessOrEqual(t, concurrency, coreGo)
+		assert.LessOrEqual(t, coreGo, maxGo)
+
+		taskDone := make(chan struct{})
+		wait := make(chan struct{})
+
+		for i := int32(0); i < maxGo; i++ {
+			err := pool.Submit(context.Background(), TaskFunc(func(ctx context.Context) error {
+				wait <- struct{}{}
+				<-taskDone
+				return nil
+			}))
+			assert.NoError(t, err)
+		}
+
+		// 提交任务后立即Shutdown
+		shutdownDone, err := pool.Shutdown()
+		assert.NoError(t, err)
+
+		// 等待close(b.queue)信号传递到各个协程
+		time.Sleep(1 * time.Second)
+
+		// 调度循环应该正常工作，一直按需开协程直到maxGo
+		for i := int32(0); i < maxGo; i++ {
+			<-wait
+		}
+		assert.Equal(t, maxGo, pool.numOfGo())
+
+		// 让所有任务结束
+		close(taskDone)
+		<-shutdownDone
+
+		// 用循环取代time.After/time.Sleep
+		for pool.numOfGo() != 0 {
+
+		}
+		assert.Equal(t, int32(0), pool.numOfGo())
 	})
 
 	t.Run("Start", func(t *testing.T) {
@@ -338,6 +737,56 @@ func TestOnDemandBlockTaskPool_In_Stopped_State(t *testing.T) {
 		assert.Equal(t, stateStopped, pool.internalState())
 	})
 
+	t.Run("ShutdownNow —— 工作协程数不再扩展，调度循环立即退出", func(t *testing.T) {
+		t.Parallel()
+
+		concurrency, coreGo, maxGo, maxIdleTime, queueBacklogRate := int32(1), int32(3), int32(5), 10*time.Millisecond, 0.1
+		queueSize := int(maxGo)
+		pool := testNewRunningStateTaskPool(t, int(concurrency), queueSize, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime), WithQueueBacklogRate(queueBacklogRate))
+
+		assert.LessOrEqual(t, concurrency, coreGo)
+		assert.LessOrEqual(t, coreGo, maxGo)
+
+		taskDone := make(chan struct{})
+		wait := make(chan struct{}, queueSize)
+
+		for i := 0; i < queueSize; i++ {
+			err := pool.Submit(context.Background(), TaskFunc(func(ctx context.Context) error {
+				wait <- struct{}{}
+				<-taskDone
+				return nil
+			}))
+			assert.NoError(t, err)
+		}
+
+		// 使调度循环进入default分支
+		for i := int32(0); i < coreGo; i++ {
+			<-wait
+		}
+
+		tasks, err := pool.ShutdownNow()
+		assert.NoError(t, err)
+		// 见下方双重检查
+		assert.GreaterOrEqual(t, len(tasks)+int(pool.numOfGo()), queueSize)
+
+		// 让所有任务结束
+		close(taskDone)
+
+		// 用循环取代time.After/time.Sleep
+		// 特殊场景需要双重检查
+		// 协程1工作中，调度循环处于default分支准备扩展协程（新增一个），此时调用ShutdownNow()
+		// 协程1完成工作接收到ShutdownNow()信号退出，而协程2还未开启可以使pool.numOfGo()短暂为0
+		// 协程2启动后直接收到ShutdownNow()信号退出
+		for pool.numOfGo() != 0 {
+
+		}
+		for pool.numOfGo() != 0 {
+
+		}
+
+		assert.Equal(t, int32(0), pool.numOfGo())
+	})
+
 	t.Run("Start", func(t *testing.T) {
 		t.Parallel()
 
@@ -408,8 +857,8 @@ type ShutdownNowResult struct {
 	err   error
 }
 
-func testNewRunningStateTaskPool(t *testing.T, concurrency int, queueSize int) *OnDemandBlockTaskPool {
-	pool, _ := NewOnDemandBlockTaskPool(concurrency, queueSize)
+func testNewRunningStateTaskPool(t *testing.T, concurrency int, queueSize int, opts ...option.Option[OnDemandBlockTaskPool]) *OnDemandBlockTaskPool {
+	pool, _ := NewOnDemandBlockTaskPool(concurrency, queueSize, opts...)
 	assert.Equal(t, stateCreated, pool.internalState())
 	assert.NoError(t, pool.Start())
 	assert.Equal(t, stateRunning, pool.internalState())
@@ -442,6 +891,34 @@ func testNewRunningStateTaskPoolWithQueueFullFilled(t *testing.T, concurrency in
 	return pool, wait
 }
 
-type FakeTask struct{}
+func TestGroup(t *testing.T) {
+	n := 10
 
-func (f *FakeTask) Run(_ context.Context) error { return nil }
+	// g := &sliceGroup{members: make([]int, n, n)}
+	g := &group{mp: make(map[int]int)}
+
+	for i := 0; i < n; i++ {
+		assert.False(t, g.isIn(i))
+		g.add(i)
+		assert.True(t, g.isIn(i))
+		assert.Equal(t, int32(i+1), g.size())
+	}
+
+	assert.Equal(t, int32(n), g.size())
+
+	for i := 0; i < n; i++ {
+		g.delete(i)
+		assert.Equal(t, int32(n-i-1), g.size())
+	}
+
+	assert.Equal(t, int32(0), g.size())
+
+	assert.False(t, g.isIn(n+1))
+
+	id := 100
+	g.add(id)
+	assert.Equal(t, int32(1), g.size())
+	assert.True(t, g.isIn(id))
+	g.delete(id)
+	assert.Equal(t, int32(0), g.size())
+}

--- a/pool/task_pool_test.go
+++ b/pool/task_pool_test.go
@@ -451,7 +451,7 @@ func testExtendNumGoFromInitGoToCoreGoAtOnce(t *testing.T, concurrency int32, qu
 		assert.Equal(t, coreGo, pool.numOfGo())
 	}
 	opts = append(opts, WithCoreGo(coreGo), WithMaxIdleTime(maxIdleTime))
-	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, coreGo, maxIdleTime, extendToCoreGoAtOnce, nil, opts...)
+	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, coreGo, extendToCoreGoAtOnce, nil, opts...)
 }
 
 func testExtendNumGoFromInitGoToCoreGoStepByStep(t *testing.T, concurrency int32, queueSize int, coreGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
@@ -459,7 +459,7 @@ func testExtendNumGoFromInitGoToCoreGoStepByStep(t *testing.T, concurrency int32
 		assert.Equal(t, i, pool.numOfGo())
 	}
 	opts = append(opts, WithCoreGo(coreGo), WithMaxIdleTime(maxIdleTime))
-	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, coreGo, maxIdleTime, extendToCoreGoAtOnce, nil, opts...)
+	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, coreGo, extendToCoreGoAtOnce, nil, opts...)
 }
 
 func testExtendNumGoFromInitGoToCoreGoAndMaxGoAtOnce(t *testing.T, concurrency int32, queueSize int, coreGo int32, maxGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
@@ -470,7 +470,7 @@ func testExtendNumGoFromInitGoToCoreGoAndMaxGoAtOnce(t *testing.T, concurrency i
 		assert.Equal(t, maxGo, pool.numOfGo())
 	}
 	opts = append(opts, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime))
-	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, maxGo, maxIdleTime, extendToCoreGoAtOnce, extendToMaxGoAtOnce, opts...)
+	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, maxGo, extendToCoreGoAtOnce, extendToMaxGoAtOnce, opts...)
 }
 
 func testExtendNumGoFromInitGoToCoreGoAndMaxGoStepByStep(t *testing.T, concurrency int32, queueSize int, coreGo, maxGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
@@ -478,10 +478,10 @@ func testExtendNumGoFromInitGoToCoreGoAndMaxGoStepByStep(t *testing.T, concurren
 		assert.Equal(t, i, pool.numOfGo())
 	}
 	opts = append(opts, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime))
-	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, maxGo, maxIdleTime, extendStepByStep, extendStepByStep, opts...)
+	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, maxGo, extendStepByStep, extendStepByStep, opts...)
 }
 
-func testExtendNumGoFromInitGoToCoreGoAndMaxGo(t *testing.T, initGo int32, queueSize int, coreGo, maxGo int32, maxIdleTime time.Duration, duringExtendToCoreGo extendStrategyCheckFunc, duringExtendToMaxGo extendStrategyCheckFunc, opts ...option.Option[OnDemandBlockTaskPool]) {
+func testExtendNumGoFromInitGoToCoreGoAndMaxGo(t *testing.T, initGo int32, queueSize int, coreGo, maxGo int32, duringExtendToCoreGo extendStrategyCheckFunc, duringExtendToMaxGo extendStrategyCheckFunc, opts ...option.Option[OnDemandBlockTaskPool]) {
 
 	pool := testNewRunningStateTaskPool(t, int(initGo), queueSize, opts...)
 	// waitTime := (maxIdleTime + 1) * 330

--- a/pool/task_pool_test.go
+++ b/pool/task_pool_test.go
@@ -71,76 +71,76 @@ func TestOnDemandBlockTaskPool_In_Created_State(t *testing.T) {
 		t.Run("With Options", func(t *testing.T) {
 			t.Parallel()
 
-			concurrency := 10
-			pool, err := NewOnDemandBlockTaskPool(concurrency, 10)
+			initGo := 10
+			pool, err := NewOnDemandBlockTaskPool(initGo, 10)
 			assert.NoError(t, err)
 
-			assert.Equal(t, int32(concurrency), pool.initGo)
-			assert.Equal(t, int32(concurrency), pool.coreGo)
-			assert.Equal(t, int32(concurrency), pool.maxGo)
+			assert.Equal(t, int32(initGo), pool.initGo)
+			assert.Equal(t, int32(initGo), pool.coreGo)
+			assert.Equal(t, int32(initGo), pool.maxGo)
 			assert.Equal(t, defaultMaxIdleTime, pool.maxIdleTime)
 
 			coreGo, maxGo, maxIdleTime := int32(20), int32(30), 10*time.Second
-			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime))
+			pool, err = NewOnDemandBlockTaskPool(initGo, 10, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime))
 			assert.NoError(t, err)
 
-			assert.Equal(t, int32(concurrency), pool.initGo)
+			assert.Equal(t, int32(initGo), pool.initGo)
 			assert.Equal(t, coreGo, pool.coreGo)
 			assert.Equal(t, maxGo, pool.maxGo)
 			assert.Equal(t, maxIdleTime, pool.maxIdleTime)
 
-			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo))
+			pool, err = NewOnDemandBlockTaskPool(initGo, 10, WithCoreGo(coreGo))
 			assert.NoError(t, err)
 			assert.Equal(t, pool.coreGo, pool.maxGo)
 
-			concurrency, coreGo = 30, 20
-			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo))
+			initGo, coreGo = 30, 20
+			pool, err = NewOnDemandBlockTaskPool(initGo, 10, WithCoreGo(coreGo))
 			assert.Nil(t, pool)
 			assert.ErrorIs(t, err, errInvalidArgument)
 
-			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithMaxGo(maxGo))
+			pool, err = NewOnDemandBlockTaskPool(initGo, 10, WithMaxGo(maxGo))
 			assert.NoError(t, err)
 			assert.Equal(t, pool.maxGo, pool.coreGo)
 
-			concurrency, maxGo = 30, 10
-			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithMaxGo(maxGo))
+			initGo, maxGo = 30, 10
+			pool, err = NewOnDemandBlockTaskPool(initGo, 10, WithMaxGo(maxGo))
 			assert.Nil(t, pool)
 			assert.ErrorIs(t, err, errInvalidArgument)
 
-			concurrency, coreGo, maxGo = 30, 20, 10
-			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
+			initGo, coreGo, maxGo = 30, 20, 10
+			pool, err = NewOnDemandBlockTaskPool(initGo, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
 			assert.Nil(t, pool)
 			assert.ErrorIs(t, err, errInvalidArgument)
 
-			concurrency, coreGo, maxGo = 30, 10, 20
-			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
+			initGo, coreGo, maxGo = 30, 10, 20
+			pool, err = NewOnDemandBlockTaskPool(initGo, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
 			assert.Nil(t, pool)
 			assert.ErrorIs(t, err, errInvalidArgument)
 
-			concurrency, coreGo, maxGo = 20, 10, 30
-			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
+			initGo, coreGo, maxGo = 20, 10, 30
+			pool, err = NewOnDemandBlockTaskPool(initGo, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
 			assert.Nil(t, pool)
 			assert.ErrorIs(t, err, errInvalidArgument)
 
-			concurrency, coreGo, maxGo = 20, 30, 10
-			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
+			initGo, coreGo, maxGo = 20, 30, 10
+			pool, err = NewOnDemandBlockTaskPool(initGo, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
 			assert.Nil(t, pool)
 			assert.ErrorIs(t, err, errInvalidArgument)
 
-			concurrency, coreGo, maxGo = 10, 30, 20
-			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
+			initGo, coreGo, maxGo = 10, 30, 20
+			pool, err = NewOnDemandBlockTaskPool(initGo, 10, WithCoreGo(coreGo), WithMaxGo(maxGo))
 			assert.Nil(t, pool)
 			assert.ErrorIs(t, err, errInvalidArgument)
 
-			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithQueueBacklogRate(-0.1))
+			pool, err = NewOnDemandBlockTaskPool(initGo, 10, WithQueueBacklogRate(-0.1))
 			assert.Nil(t, pool)
 			assert.ErrorIs(t, err, errInvalidArgument)
 
-			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithQueueBacklogRate(1.0))
+			pool, err = NewOnDemandBlockTaskPool(initGo, 10, WithQueueBacklogRate(1.0))
 			assert.NotNil(t, pool)
 			assert.NoError(t, err)
 
-			pool, err = NewOnDemandBlockTaskPool(concurrency, 10, WithQueueBacklogRate(1.1))
+			pool, err = NewOnDemandBlockTaskPool(initGo, 10, WithQueueBacklogRate(1.1))
 			assert.Nil(t, pool)
 			assert.ErrorIs(t, err, errInvalidArgument)
 
@@ -272,8 +272,8 @@ func TestOnDemandBlockTaskPool_In_Running_State(t *testing.T) {
 		t.Run("保持在初始数不变", func(t *testing.T) {
 			t.Parallel()
 
-			concurrency, queueSize := 1, 3
-			pool := testNewRunningStateTaskPool(t, concurrency, queueSize)
+			initGo, queueSize := 1, 3
+			pool := testNewRunningStateTaskPool(t, initGo, queueSize)
 
 			n := queueSize
 			done1 := make(chan struct{}, n)
@@ -289,22 +289,22 @@ func TestOnDemandBlockTaskPool_In_Running_State(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			// concurrency个tasks在运行中
-			for i := 0; i < concurrency; i++ {
+			// initGo个tasks在运行中
+			for i := 0; i < initGo; i++ {
 				<-wait
 			}
 
-			assert.Equal(t, int32(concurrency), pool.numOfGo())
+			assert.Equal(t, int32(initGo), pool.numOfGo())
 
 			// 使运行中的tasks结束
-			for i := 0; i < concurrency; i++ {
+			for i := 0; i < initGo; i++ {
 				done1 <- struct{}{}
 			}
 
 			// 积压在队列中的任务开始运行
-			for i := 0; i < n-concurrency; i++ {
+			for i := 0; i < n-initGo; i++ {
 				<-wait
-				assert.Equal(t, int32(concurrency), pool.numOfGo())
+				assert.Equal(t, int32(initGo), pool.numOfGo())
 				done1 <- struct{}{}
 			}
 
@@ -319,17 +319,17 @@ func TestOnDemandBlockTaskPool_In_Running_State(t *testing.T) {
 				t.Run("核心数比初始数多1个", func(t *testing.T) {
 					t.Parallel()
 
-					concurrency, coreGo, maxIdleTime := int32(1), int32(2), 3*time.Millisecond
+					initGo, coreGo, maxIdleTime := int32(1), int32(2), 3*time.Millisecond
 					queueSize := int(coreGo)
-					testExtendNumGoFromInitGoToCoreGoAtOnce(t, concurrency, queueSize, coreGo, maxIdleTime)
+					testExtendNumGoFromInitGoToCoreGoAtOnce(t, initGo, queueSize, coreGo, maxIdleTime)
 				})
 
 				t.Run("核心数比初始数多n个", func(t *testing.T) {
 					t.Parallel()
 
-					concurrency, coreGo, maxIdleTime := int32(1), int32(3), 3*time.Millisecond
+					initGo, coreGo, maxIdleTime := int32(1), int32(3), 3*time.Millisecond
 					queueSize := int(coreGo)
-					testExtendNumGoFromInitGoToCoreGoAtOnce(t, concurrency, queueSize, coreGo, maxIdleTime)
+					testExtendNumGoFromInitGoToCoreGoAtOnce(t, initGo, queueSize, coreGo, maxIdleTime)
 				})
 			})
 
@@ -337,17 +337,17 @@ func TestOnDemandBlockTaskPool_In_Running_State(t *testing.T) {
 				t.Parallel()
 
 				t.Run("核心数比初始数多1个", func(t *testing.T) {
-					concurrency, coreGo, maxIdleTime, queueBacklogRate := int32(2), int32(3), 3*time.Millisecond, 0.1
+					initGo, coreGo, maxIdleTime, queueBacklogRate := int32(2), int32(3), 3*time.Millisecond, 0.1
 					queueSize := int(coreGo)
-					testExtendNumGoFromInitGoToCoreGoStepByStep(t, concurrency, queueSize, coreGo, maxIdleTime, WithQueueBacklogRate(queueBacklogRate))
+					testExtendNumGoFromInitGoToCoreGoStepByStep(t, initGo, queueSize, coreGo, maxIdleTime, WithQueueBacklogRate(queueBacklogRate))
 				})
 
 				t.Run("核心数比初始数多n个", func(t *testing.T) {
 					t.Parallel()
 
-					concurrency, coreGo, maxIdleTime, queueBacklogRate := int32(2), int32(5), 3*time.Millisecond, 0.1
+					initGo, coreGo, maxIdleTime, queueBacklogRate := int32(2), int32(5), 3*time.Millisecond, 0.1
 					queueSize := int(coreGo)
-					testExtendNumGoFromInitGoToCoreGoStepByStep(t, concurrency, queueSize, coreGo, maxIdleTime, WithQueueBacklogRate(queueBacklogRate))
+					testExtendNumGoFromInitGoToCoreGoStepByStep(t, initGo, queueSize, coreGo, maxIdleTime, WithQueueBacklogRate(queueBacklogRate))
 
 				})
 			})
@@ -355,10 +355,10 @@ func TestOnDemandBlockTaskPool_In_Running_State(t *testing.T) {
 			t.Run("在(初始数,核心数]区间的协程运行完任务后，在等待退出期间再次抢到任务", func(t *testing.T) {
 				t.Parallel()
 
-				concurrency, coreGo, maxIdleTime := int32(1), int32(6), 100*time.Millisecond
+				initGo, coreGo, maxIdleTime := int32(1), int32(6), 100*time.Millisecond
 				queueSize := int(coreGo)
 
-				pool := testNewRunningStateTaskPool(t, int(concurrency), queueSize, WithCoreGo(coreGo), WithMaxIdleTime(maxIdleTime))
+				pool := testNewRunningStateTaskPool(t, int(initGo), queueSize, WithCoreGo(coreGo), WithMaxIdleTime(maxIdleTime))
 				done := make(chan struct{}, queueSize)
 				wait := make(chan struct{}, queueSize)
 
@@ -388,11 +388,11 @@ func TestOnDemandBlockTaskPool_In_Running_State(t *testing.T) {
 				assert.NoError(t, err)
 
 				// <-time.After(maxIdleTime * 100)
-				for pool.numOfGo() > concurrency {
+				for pool.numOfGo() > initGo {
 					// t.Log("loop", "numOfGo", pool.numOfGo(), "timeoutGroup", pool.timeoutGroup.size())
 					time.Sleep(maxIdleTime)
 				}
-				assert.Equal(t, concurrency, pool.numOfGo())
+				assert.Equal(t, initGo, pool.numOfGo())
 			})
 		})
 
@@ -405,17 +405,17 @@ func TestOnDemandBlockTaskPool_In_Running_State(t *testing.T) {
 				t.Run("最大数比核心数多1个", func(t *testing.T) {
 					t.Parallel()
 
-					concurrency, coreGo, maxGo, maxIdleTime := int32(2), int32(4), int32(5), 3*time.Millisecond
+					initGo, coreGo, maxGo, maxIdleTime := int32(2), int32(4), int32(5), 3*time.Millisecond
 					queueSize := int(maxGo)
-					testExtendNumGoFromInitGoToCoreGoAndMaxGoAtOnce(t, concurrency, queueSize, coreGo, maxGo, maxIdleTime)
+					testExtendNumGoFromInitGoToCoreGoAndMaxGoAtOnce(t, initGo, queueSize, coreGo, maxGo, maxIdleTime)
 				})
 
 				t.Run("最大数比核心数多n个", func(t *testing.T) {
 					t.Parallel()
 
-					concurrency, coreGo, maxGo, maxIdleTime := int32(2), int32(3), int32(5), 3*time.Millisecond
+					initGo, coreGo, maxGo, maxIdleTime := int32(2), int32(3), int32(5), 3*time.Millisecond
 					queueSize := int(maxGo)
-					testExtendNumGoFromInitGoToCoreGoAndMaxGoAtOnce(t, concurrency, queueSize, coreGo, maxGo, maxIdleTime)
+					testExtendNumGoFromInitGoToCoreGoAndMaxGoAtOnce(t, initGo, queueSize, coreGo, maxGo, maxIdleTime)
 				})
 
 			})
@@ -426,17 +426,17 @@ func TestOnDemandBlockTaskPool_In_Running_State(t *testing.T) {
 				t.Run("最大数比核心数多1个", func(t *testing.T) {
 					t.Parallel()
 
-					concurrency, coreGo, maxGo, maxIdleTime, queueBacklogRate := int32(2), int32(4), int32(5), 3*time.Millisecond, 0.1
+					initGo, coreGo, maxGo, maxIdleTime, queueBacklogRate := int32(2), int32(4), int32(5), 3*time.Millisecond, 0.1
 					queueSize := int(maxGo)
-					testExtendNumGoFromInitGoToCoreGoAndMaxGoStepByStep(t, concurrency, queueSize, coreGo, maxGo, maxIdleTime, WithQueueBacklogRate(queueBacklogRate))
+					testExtendNumGoFromInitGoToCoreGoAndMaxGoStepByStep(t, initGo, queueSize, coreGo, maxGo, maxIdleTime, WithQueueBacklogRate(queueBacklogRate))
 				})
 
 				t.Run("最大数比核心数多n个", func(t *testing.T) {
 					t.Parallel()
 
-					concurrency, coreGo, maxGo, maxIdleTime, queueBacklogRate := int32(1), int32(3), int32(6), 3*time.Millisecond, 0.1
+					initGo, coreGo, maxGo, maxIdleTime, queueBacklogRate := int32(1), int32(3), int32(6), 3*time.Millisecond, 0.1
 					queueSize := int(maxGo)
-					testExtendNumGoFromInitGoToCoreGoAndMaxGoStepByStep(t, concurrency, queueSize, coreGo, maxGo, maxIdleTime, WithQueueBacklogRate(queueBacklogRate))
+					testExtendNumGoFromInitGoToCoreGoAndMaxGoStepByStep(t, initGo, queueSize, coreGo, maxGo, maxIdleTime, WithQueueBacklogRate(queueBacklogRate))
 				})
 			})
 		})
@@ -446,23 +446,23 @@ func TestOnDemandBlockTaskPool_In_Running_State(t *testing.T) {
 
 type extendStrategyCheckFunc func(t *testing.T, i int32, pool *OnDemandBlockTaskPool)
 
-func testExtendNumGoFromInitGoToCoreGoAtOnce(t *testing.T, concurrency int32, queueSize int, coreGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
+func testExtendNumGoFromInitGoToCoreGoAtOnce(t *testing.T, initGo int32, queueSize int, coreGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
 	extendToCoreGoAtOnce := func(t *testing.T, i int32, pool *OnDemandBlockTaskPool) {
 		assert.Equal(t, coreGo, pool.numOfGo())
 	}
 	opts = append(opts, WithCoreGo(coreGo), WithMaxIdleTime(maxIdleTime))
-	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, coreGo, extendToCoreGoAtOnce, nil, opts...)
+	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, initGo, queueSize, coreGo, coreGo, extendToCoreGoAtOnce, nil, opts...)
 }
 
-func testExtendNumGoFromInitGoToCoreGoStepByStep(t *testing.T, concurrency int32, queueSize int, coreGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
+func testExtendNumGoFromInitGoToCoreGoStepByStep(t *testing.T, initGo int32, queueSize int, coreGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
 	extendToCoreGoAtOnce := func(t *testing.T, i int32, pool *OnDemandBlockTaskPool) {
 		assert.Equal(t, i, pool.numOfGo())
 	}
 	opts = append(opts, WithCoreGo(coreGo), WithMaxIdleTime(maxIdleTime))
-	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, coreGo, extendToCoreGoAtOnce, nil, opts...)
+	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, initGo, queueSize, coreGo, coreGo, extendToCoreGoAtOnce, nil, opts...)
 }
 
-func testExtendNumGoFromInitGoToCoreGoAndMaxGoAtOnce(t *testing.T, concurrency int32, queueSize int, coreGo int32, maxGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
+func testExtendNumGoFromInitGoToCoreGoAndMaxGoAtOnce(t *testing.T, initGo int32, queueSize int, coreGo int32, maxGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
 	extendToCoreGoAtOnce := func(t *testing.T, i int32, pool *OnDemandBlockTaskPool) {
 		assert.Equal(t, coreGo, pool.numOfGo())
 	}
@@ -470,21 +470,20 @@ func testExtendNumGoFromInitGoToCoreGoAndMaxGoAtOnce(t *testing.T, concurrency i
 		assert.Equal(t, maxGo, pool.numOfGo())
 	}
 	opts = append(opts, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime))
-	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, maxGo, extendToCoreGoAtOnce, extendToMaxGoAtOnce, opts...)
+	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, initGo, queueSize, coreGo, maxGo, extendToCoreGoAtOnce, extendToMaxGoAtOnce, opts...)
 }
 
-func testExtendNumGoFromInitGoToCoreGoAndMaxGoStepByStep(t *testing.T, concurrency int32, queueSize int, coreGo, maxGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
+func testExtendNumGoFromInitGoToCoreGoAndMaxGoStepByStep(t *testing.T, initGo int32, queueSize int, coreGo, maxGo int32, maxIdleTime time.Duration, opts ...option.Option[OnDemandBlockTaskPool]) {
 	extendStepByStep := func(t *testing.T, i int32, pool *OnDemandBlockTaskPool) {
 		assert.Equal(t, i, pool.numOfGo())
 	}
 	opts = append(opts, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime))
-	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, concurrency, queueSize, coreGo, maxGo, extendStepByStep, extendStepByStep, opts...)
+	testExtendNumGoFromInitGoToCoreGoAndMaxGo(t, initGo, queueSize, coreGo, maxGo, extendStepByStep, extendStepByStep, opts...)
 }
 
 func testExtendNumGoFromInitGoToCoreGoAndMaxGo(t *testing.T, initGo int32, queueSize int, coreGo, maxGo int32, duringExtendToCoreGo extendStrategyCheckFunc, duringExtendToMaxGo extendStrategyCheckFunc, opts ...option.Option[OnDemandBlockTaskPool]) {
 
 	pool := testNewRunningStateTaskPool(t, int(initGo), queueSize, opts...)
-	// waitTime := (maxIdleTime + 1) * 330
 
 	assert.LessOrEqual(t, initGo, coreGo)
 	assert.LessOrEqual(t, coreGo, maxGo)
@@ -492,7 +491,7 @@ func testExtendNumGoFromInitGoToCoreGoAndMaxGo(t *testing.T, initGo int32, queue
 	done := make(chan struct{})
 	wait := make(chan struct{}, maxGo)
 
-	// 稳定在concurrency
+	// 稳定在initGo
 	for i := int32(0); i < initGo; i++ {
 		err := pool.Submit(context.Background(), TaskFunc(func(ctx context.Context) error {
 			wait <- struct{}{}
@@ -561,11 +560,11 @@ func TestOnDemandBlockTaskPool_In_Closing_State(t *testing.T) {
 	t.Run("Shutdown —— 使TaskPool状态由Running变为Closing", func(t *testing.T) {
 		t.Parallel()
 
-		concurrency, queueSize := 2, 4
-		pool := testNewRunningStateTaskPool(t, concurrency, queueSize)
+		initGo, queueSize := 2, 4
+		pool := testNewRunningStateTaskPool(t, initGo, queueSize)
 
 		// 模拟阻塞提交
-		n := concurrency + queueSize*2
+		n := initGo + queueSize*2
 		eg := new(errgroup.Group)
 		waitChan := make(chan struct{}, n)
 		taskDone := make(chan struct{})
@@ -578,7 +577,7 @@ func TestOnDemandBlockTaskPool_In_Closing_State(t *testing.T) {
 				}))
 			})
 		}
-		for i := 0; i < concurrency; i++ {
+		for i := 0; i < initGo; i++ {
 			<-waitChan
 		}
 		done, err := pool.Shutdown()
@@ -592,7 +591,7 @@ func TestOnDemandBlockTaskPool_In_Closing_State(t *testing.T) {
 		assert.ErrorIs(t, err2, errTaskPoolIsClosing)
 		assert.Equal(t, stateClosing, pool.internalState())
 
-		assert.Equal(t, int32(concurrency), pool.numOfGo())
+		assert.Equal(t, int32(initGo), pool.numOfGo())
 
 		close(taskDone)
 		<-done
@@ -608,11 +607,11 @@ func TestOnDemandBlockTaskPool_In_Closing_State(t *testing.T) {
 	t.Run("Shutdown —— 协程数仍能按需扩展，调度循环也能自然退出", func(t *testing.T) {
 		t.Parallel()
 
-		concurrency, coreGo, maxGo, maxIdleTime, queueBacklogRate := int32(1), int32(3), int32(5), 10*time.Millisecond, 0.1
+		initGo, coreGo, maxGo, maxIdleTime, queueBacklogRate := int32(1), int32(3), int32(5), 10*time.Millisecond, 0.1
 		queueSize := int(maxGo)
-		pool := testNewRunningStateTaskPool(t, int(concurrency), queueSize, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime), WithQueueBacklogRate(queueBacklogRate))
+		pool := testNewRunningStateTaskPool(t, int(initGo), queueSize, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime), WithQueueBacklogRate(queueBacklogRate))
 
-		assert.LessOrEqual(t, concurrency, coreGo)
+		assert.LessOrEqual(t, initGo, coreGo)
 		assert.LessOrEqual(t, coreGo, maxGo)
 
 		taskDone := make(chan struct{})
@@ -700,8 +699,8 @@ func TestOnDemandBlockTaskPool_In_Stopped_State(t *testing.T) {
 	t.Run("ShutdownNow —— 使TaskPool状态由Running变为Stopped", func(t *testing.T) {
 		t.Parallel()
 
-		concurrency, queueSize := 2, 4
-		pool, wait := testNewRunningStateTaskPoolWithQueueFullFilled(t, concurrency, queueSize)
+		initGo, queueSize := 2, 4
+		pool, wait := testNewRunningStateTaskPoolWithQueueFullFilled(t, initGo, queueSize)
 
 		// 模拟阻塞提交
 		eg := new(errgroup.Group)
@@ -740,11 +739,11 @@ func TestOnDemandBlockTaskPool_In_Stopped_State(t *testing.T) {
 	t.Run("ShutdownNow —— 工作协程数不再扩展，调度循环立即退出", func(t *testing.T) {
 		t.Parallel()
 
-		concurrency, coreGo, maxGo, maxIdleTime, queueBacklogRate := int32(1), int32(3), int32(5), 10*time.Millisecond, 0.1
+		initGo, coreGo, maxGo, maxIdleTime, queueBacklogRate := int32(1), int32(3), int32(5), 10*time.Millisecond, 0.1
 		queueSize := int(maxGo)
-		pool := testNewRunningStateTaskPool(t, int(concurrency), queueSize, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime), WithQueueBacklogRate(queueBacklogRate))
+		pool := testNewRunningStateTaskPool(t, int(initGo), queueSize, WithCoreGo(coreGo), WithMaxGo(maxGo), WithMaxIdleTime(maxIdleTime), WithQueueBacklogRate(queueBacklogRate))
 
-		assert.LessOrEqual(t, concurrency, coreGo)
+		assert.LessOrEqual(t, initGo, coreGo)
 		assert.LessOrEqual(t, coreGo, maxGo)
 
 		taskDone := make(chan struct{})
@@ -857,16 +856,16 @@ type ShutdownNowResult struct {
 	err   error
 }
 
-func testNewRunningStateTaskPool(t *testing.T, concurrency int, queueSize int, opts ...option.Option[OnDemandBlockTaskPool]) *OnDemandBlockTaskPool {
-	pool, _ := NewOnDemandBlockTaskPool(concurrency, queueSize, opts...)
+func testNewRunningStateTaskPool(t *testing.T, initGo int, queueSize int, opts ...option.Option[OnDemandBlockTaskPool]) *OnDemandBlockTaskPool {
+	pool, _ := NewOnDemandBlockTaskPool(initGo, queueSize, opts...)
 	assert.Equal(t, stateCreated, pool.internalState())
 	assert.NoError(t, pool.Start())
 	assert.Equal(t, stateRunning, pool.internalState())
 	return pool
 }
 
-func testNewStoppedStateTaskPool(t *testing.T, concurrency int, queueSize int) *OnDemandBlockTaskPool {
-	pool := testNewRunningStateTaskPool(t, concurrency, queueSize)
+func testNewStoppedStateTaskPool(t *testing.T, initGo int, queueSize int) *OnDemandBlockTaskPool {
+	pool := testNewRunningStateTaskPool(t, initGo, queueSize)
 	tasks, err := pool.ShutdownNow()
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(tasks))
@@ -874,10 +873,10 @@ func testNewStoppedStateTaskPool(t *testing.T, concurrency int, queueSize int) *
 	return pool
 }
 
-func testNewRunningStateTaskPoolWithQueueFullFilled(t *testing.T, concurrency int, queueSize int) (*OnDemandBlockTaskPool, chan struct{}) {
-	pool := testNewRunningStateTaskPool(t, concurrency, queueSize)
+func testNewRunningStateTaskPoolWithQueueFullFilled(t *testing.T, initGo int, queueSize int) (*OnDemandBlockTaskPool, chan struct{}) {
+	pool := testNewRunningStateTaskPool(t, initGo, queueSize)
 	wait := make(chan struct{})
-	for i := 0; i < concurrency+queueSize; i++ {
+	for i := 0; i < initGo+queueSize; i++ {
 		func() {
 			err := pool.Submit(context.Background(), TaskFunc(func(ctx context.Context) error {
 				<-wait


### PR DESCRIPTION
根据 #80 中讨论尤其是 [讨论1](https://github.com/gotomicro/ekit/pull/80#discussion_r966717803)和[讨论2](https://github.com/gotomicro/ekit/pull/80#discussion_r967837196)

最终我没有采取在[讨论2](https://github.com/gotomicro/ekit/pull/80#discussion_r967837196)提到的**按协程分类创建**策略.原因如下:

1. 代码结构上的重复,只有微小差别,还不好抽出方法来复用.
2. 沿用 #80 中的例子,当协程数达到最大协程数即30时,此时初始协程数的协程们(10个)恰好运行任务结束,它们既没有任务运行也不能退出.当初始数、核心数及最大数的数值很大时更是一个问题.

本次重构采用的是在协程**运行任务结束后**,根据当前协程总数(totalNumOfGo)与初始数(10, initGo),核心数(20, coreGo)的关系来动态随机划分协程.并保证最终稳定在“初始数”即10个. 算法如下:

1. 如果当前协程满足`b.coreGo < b.totalNumOfGo && (len(b.queue) == 0 || int32(len(b.queue)) < b.totalNumOfGo) `则更新协程总数并直接退出
2. 如果当前协程满足`b.initGo < b.totalNumOfGo-b.timeoutGroup.size()`那么当前协程会被设置定时器,在“最大空闲时间”内没接到任务会因为超时而退出.
3. 其他情况要么因为队列中有任务,要么因为当前协程处于“初始数”组中不处理.

timeoutGroup是超时组,有两个作用:

1. 通过协程id将其标记为“核心组”/超时组,使`b.totalNumOfGo-b.timeoutGroup.size()`能够准确反应结果保证动态分类的正确性
2. timeoutGroup明确表示意图,而不是用idleTimer来表示这个逻辑分组.不再依赖于idleTimer.Stop这个不确定性大的方法
 





