### PR TITLE
sqlx 加密列 key长度校验

### DIFF
--- a/sqlx/encrypt.go
+++ b/sqlx/encrypt.go
@@ -48,7 +48,7 @@ func (e EncryptColumn[T]) Value() (driver.Value, error) {
 	if !e.Valid {
 		return nil, errInvalid
 	}
-	if len(e.Key) != 16 || len(e.Key) != 24 || len(e.Key) != 32 {
+	if len(e.Key) != 16 && len(e.Key) != 24 && len(e.Key) != 32 {
 		return nil, errKeyLengthInvalid
 	}
 	var val any = e.Val

--- a/sqlx/encrypt.go
+++ b/sqlx/encrypt.go
@@ -39,6 +39,7 @@ type EncryptColumn[T any] struct {
 }
 
 var errInvalid = errors.New("ekit EncryptColumn无效")
+var errKeyLengthInvalid = errors.New("ekit EncryptColumn key 长度不合法")
 
 // Value 返回加密后的值
 // 如果 T 是基本类型，那么会对 T 进行直接加密
@@ -46,6 +47,9 @@ var errInvalid = errors.New("ekit EncryptColumn无效")
 func (e EncryptColumn[T]) Value() (driver.Value, error) {
 	if !e.Valid {
 		return nil, errInvalid
+	}
+	if len(e.Key) != 16 || len(e.Key) != 24 || len(e.Key) != 32 {
+		return nil, errKeyLengthInvalid
 	}
 	var val any = e.Val
 	var err error

--- a/sqlx/encrypt_test.go
+++ b/sqlx/encrypt_test.go
@@ -37,6 +37,11 @@ func TestEncryptColumn_Basic(t *testing.T) {
 		wantDeErr error
 	}{
 		{
+			name:      "wrong length key",
+			input:     &EncryptColumn[string]{Key: "ABC", Val: "abc", Valid: true},
+			wantEnErr: errKeyLengthInvalid,
+		},
+		{
 			name:   "int",
 			input:  &EncryptColumn[int32]{Key: "ABCDABCDABCDABCDABCDABCDABCDABCD", Val: 123, Valid: true},
 			output: &EncryptColumn[int32]{Key: "ABCDABCDABCDABCDABCDABCDABCDABCD"},


### PR DESCRIPTION
go中gcm加密算法中的仅支持16、24、32的key，在加密列工具中是否应该增加下对key的校验？将错误包装一下提示给用户

这是aes中的NewCipher方法
```
// NewCipher creates and returns a new cipher.Block.
// The key argument should be the AES key,
// either 16, 24, or 32 bytes to select
// AES-128, AES-192, or AES-256.
func NewCipher(key []byte) (cipher.Block, error) {
	k := len(key)
	switch k {
	default:
		return nil, KeySizeError(k)
	case 16, 24, 32:
		break
	}
	if boring.Enabled {
		return boring.NewAESCipher(key)
	}
	return newCipher(key)
}
```