### PR TITLE
queue: 定义 Queue 接口

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -1,5 +1,6 @@
 # 开发中
 - [atomicx: 泛型封装 atomic.Value](https://github.com/gotomicro/ekit/pull/101)
+- [queue: Queue 接口定义](https://github.com/gotomicro/ekit/pull/108)
 
 # v0.0.4
 - [slice: 重构 index 和 contains 的方法，直接调用对应Func 版本](https://github.com/gotomicro/ekit/pull/87)

--- a/internal/queue/types.go
+++ b/internal/queue/types.go
@@ -1,0 +1,29 @@
+// Copyright 2021 gotomicro
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue
+
+import "context"
+
+// Queue 是队列的顶级接口
+// 一个队列是否会阻塞调用取决于具体的实现
+// 队列是否遵循 FIFO 也取决于具体实现
+type Queue[T any] interface {
+	// Put 将一个元素放入队列中
+	// 对于阻塞队列来说，如果当前队列已满，那么调用者会被阻塞，直到 ctx 超时
+	Put(ctx context.Context, t T) error
+	// Poll 从队头移除一个元素，并返回该元素
+	// 对于阻塞队列来说，如果队列为空，那么调用者会被阻塞，直到 ctx 超时
+	Poll(ctx context.Context) (T, error)
+}

--- a/list/array_list.go
+++ b/list/array_list.go
@@ -15,6 +15,8 @@
 package list
 
 import (
+	"context"
+
 	"github.com/gotomicro/ekit/internal/errs"
 	"github.com/gotomicro/ekit/internal/slice"
 )
@@ -38,6 +40,14 @@ func NewArrayListOf[T any](ts []T) *ArrayList[T] {
 	return &ArrayList[T]{
 		vals: ts,
 	}
+}
+
+func (a *ArrayList[T]) Put(ctx context.Context, t T) error {
+	return a.Append(t)
+}
+
+func (a *ArrayList[T]) Poll(ctx context.Context) (T, error) {
+	return a.Delete(0)
 }
 
 func (a *ArrayList[T]) Get(index int) (t T, e error) {

--- a/list/array_list_test.go
+++ b/list/array_list_test.go
@@ -15,14 +15,86 @@
 package list
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/gotomicro/ekit/internal/errs"
-
 	"github.com/stretchr/testify/assert"
 )
+
+func TestArrayList_Poll(t *testing.T) {
+	testCases := []struct {
+		name      string
+		list      *ArrayList[int]
+		wantVal   int
+		wantErr   error
+		wantSlice []int
+	}{
+		{
+			name:    "empty",
+			list:    NewArrayList[int](2),
+			wantErr: errs.NewErrIndexOutOfRange(0, 0),
+		},
+		{
+			name:      "only one",
+			list:      NewArrayListOf[int]([]int{1}),
+			wantVal:   1,
+			wantSlice: []int{},
+		},
+		{
+			name:      "multiple",
+			list:      NewArrayListOf[int]([]int{1, 2, 3}),
+			wantVal:   1,
+			wantSlice: []int{2, 3},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := tc.list.Poll(context.Background())
+			assert.Equal(t, tc.wantErr, err)
+			if err != nil {
+				return
+			}
+			assert.Equal(t, tc.wantVal, val)
+			assert.Equal(t, tc.wantSlice, tc.list.vals)
+		})
+	}
+}
+
+func TestArrayList_Put(t *testing.T) {
+	testCases := []struct {
+		name      string
+		list      *ArrayList[int]
+		val       int
+		wantSlice []int
+		wantErr   error
+	}{
+		{
+			name:      "empty",
+			list:      NewArrayList[int](2),
+			val:       1,
+			wantSlice: []int{1},
+		},
+		{
+			name:      "not empty",
+			list:      NewArrayListOf[int]([]int{1, 2, 3}),
+			val:       4,
+			wantSlice: []int{1, 2, 3, 4},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.list.Put(context.Background(), tc.val)
+			assert.Equal(t, tc.wantErr, err)
+			if err != nil {
+				return
+			}
+			assert.Equal(t, tc.wantSlice, tc.list.vals)
+		})
+	}
+}
 
 func TestArrayList_Add(t *testing.T) {
 	testCases := []struct {

--- a/list/concurrent_list.go
+++ b/list/concurrent_list.go
@@ -14,7 +14,10 @@
 
 package list
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
 
 var (
 	_ List[any] = &ConcurrentList[any]{}
@@ -25,6 +28,18 @@ var (
 type ConcurrentList[T any] struct {
 	List[T]
 	lock sync.RWMutex
+}
+
+func (c *ConcurrentList[T]) Put(ctx context.Context, t T) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.List.Put(ctx, t)
+}
+
+func (c *ConcurrentList[T]) Poll(ctx context.Context) (T, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.List.Poll(ctx)
 }
 
 func (c *ConcurrentList[T]) Get(index int) (T, error) {

--- a/list/linked_list.go
+++ b/list/linked_list.go
@@ -14,7 +14,11 @@
 
 package list
 
-import "github.com/gotomicro/ekit/internal/errs"
+import (
+	"context"
+
+	"github.com/gotomicro/ekit/internal/errs"
+)
 
 var (
 	_ List[any] = &LinkedList[any]{}
@@ -54,6 +58,14 @@ func NewLinkedListOf[T any](ts []T) *LinkedList[T] {
 	return list
 }
 
+func (l *LinkedList[T]) Put(ctx context.Context, t T) error {
+	return l.Append(t)
+}
+
+func (l *LinkedList[T]) Poll(ctx context.Context) (T, error) {
+	return l.Delete(0)
+}
+
 func (l *LinkedList[T]) findNode(index int) *node[T] {
 	var cur *node[T]
 	if index <= l.Len()/2 {
@@ -87,8 +99,8 @@ func (l *LinkedList[T]) checkIndex(index int) bool {
 // Append 往链表最后添加元素
 func (l *LinkedList[T]) Append(ts ...T) error {
 	for _, t := range ts {
-		node := &node[T]{prev: l.tail.prev, next: l.tail, val: t}
-		node.prev.next, node.next.prev = node, node
+		n := &node[T]{prev: l.tail.prev, next: l.tail, val: t}
+		n.prev.next, n.next.prev = n, n
 		l.length++
 	}
 	return nil

--- a/list/linked_list_test.go
+++ b/list/linked_list_test.go
@@ -15,14 +15,89 @@
 package list
 
 import (
+	"context"
 	"errors"
 	"fmt"
+
+	"github.com/gotomicro/ekit/internal/errs"
 
 	"github.com/stretchr/testify/assert"
 
 	"math/rand"
 	"testing"
 )
+
+func TestLinkedList_Poll(t *testing.T) {
+	testCases := []struct {
+		name      string
+		list      *LinkedList[int]
+		wantVal   int
+		wantErr   error
+		wantSlice []int
+	}{
+		{
+			name:    "empty",
+			list:    NewLinkedList[int](),
+			wantErr: errs.NewErrIndexOutOfRange(0, 0),
+		},
+		{
+			name:      "only one",
+			list:      NewLinkedListOf[int]([]int{1}),
+			wantVal:   1,
+			wantSlice: []int{},
+		},
+		{
+			name:      "multiple",
+			list:      NewLinkedListOf[int]([]int{1, 2, 3}),
+			wantVal:   1,
+			wantSlice: []int{2, 3},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := tc.list.Poll(context.Background())
+			assert.Equal(t, tc.wantErr, err)
+			if err != nil {
+				return
+			}
+			assert.Equal(t, tc.wantVal, val)
+			assert.Equal(t, tc.wantSlice, tc.list.AsSlice())
+		})
+	}
+}
+
+func TestLinkedList_Put(t *testing.T) {
+	testCases := []struct {
+		name      string
+		list      *LinkedList[int]
+		val       int
+		wantSlice []int
+		wantErr   error
+	}{
+		{
+			name:      "empty",
+			list:      NewLinkedList[int](),
+			val:       1,
+			wantSlice: []int{1},
+		},
+		{
+			name:      "not empty",
+			list:      NewLinkedListOf[int]([]int{1, 2, 3}),
+			val:       4,
+			wantSlice: []int{1, 2, 3, 4},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.list.Put(context.Background(), tc.val)
+			assert.Equal(t, tc.wantErr, err)
+			if err != nil {
+				return
+			}
+			assert.Equal(t, tc.wantSlice, tc.list.AsSlice())
+		})
+	}
+}
 
 func TestLinkedList_Add(t *testing.T) {
 	testCases := []struct {

--- a/list/types.go
+++ b/list/types.go
@@ -14,9 +14,12 @@
 
 package list
 
+import "github.com/gotomicro/ekit/internal/queue"
+
 // List 接口
 // 该接口只定义清楚各个方法的行为和表现
 type List[T any] interface {
+	queue.Queue[T]
 	// Get 返回对应下标的元素，
 	// 在下标超出范围的情况下，返回错误
 	Get(index int) (T, error)

--- a/queue/types.go
+++ b/queue/types.go
@@ -1,0 +1,21 @@
+// Copyright 2021 gotomicro
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue
+
+import (
+	"github.com/gotomicro/ekit/internal/queue"
+)
+
+type Queue[T any] queue.Queue[T]


### PR DESCRIPTION
- 定义 Queue 接口
- List 接口组合 Queue 接口
- 重构已有的 List 实现，支持 Queue 接口

虽然在设想里面我还需要在接口里面定义更加多的方法，但是目前我并不想添加得那么快。

方法定义主要参考的是 Java 中的 BlockingQueue。不过因为在 Go 里面天然就有一个 context.Context，所以我们不需要区别 Queue，或者 BlockingQueue
- [BlockingQueue](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/BlockingQueue.html)
- [Queue](https://docs.oracle.com/javase/8/docs/api/java/util/Queue.html)

暂时来说，我觉得只需要这两个方法就可以：
- Put，添加一个元素到队列中。这里我并没有强调是加到队尾，因为很显然，在优先级队列里面，它不一定就被加进去了队尾
- Poll，从队头获取一个元素。这个反而是确定无疑是从队头获得的，因为即便是在优先级队列的场景之下，队头的永远是最高优先级的

这两个方法的名字，并不太好取。还有可能的候选项是：
- Add：添加一个元素
- Pick：从队头获取一个元素

也可以考虑类似栈的命名
- Push：
- Pop：

List 天然就是一个队列，所以我显式组合了 Queue 接口