### PR TITLE
基于SingleFlight思想实现基于时间的线程安全优先级队列

### DIFF
--- a/queue/delay_queue.go
+++ b/queue/delay_queue.go
@@ -18,7 +18,7 @@ var (
 )
 
 type Delayable[T any] interface {
-	Delay() time.Duration
+	Deadline() time.Time
 }
 
 type DelayQueue[T Delayable[T]] struct {
@@ -336,7 +336,7 @@ func (d *DelayQueue[T]) dequeueProxy() {
 			goto blocking
 		}
 
-		remainingBlockingDuration = head.Delay() - time.Duration(time.Now().Unix())
+		remainingBlockingDuration = time.Duration(head.Deadline().Unix() - time.Now().Unix())
 		if remainingBlockingDuration > 0 {
 			// 数据未过期
 			log.Println("dequeueProxy, blocking before, waiting duration ....", head, remainingBlockingDuration, time.Now())

--- a/queue/delay_queue.go
+++ b/queue/delay_queue.go
@@ -1,0 +1,174 @@
+package queue
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gotomicro/ekit"
+	"github.com/gotomicro/ekit/internal/queue"
+)
+
+type Delayable[T any] interface {
+	Delay() time.Duration
+}
+
+type DelayQueue[T Delayable[T]] struct {
+	q     *queue.PriorityQueue[T]
+	mutex *sync.RWMutex
+
+	compareFunc ekit.Comparator[T]
+
+	headOfQueueHasChangedSignal chan struct{}
+	SignalSenders               int64
+
+	SignalReceivers int64
+}
+
+func NewDelayQueue[T Delayable[T]](compare ekit.Comparator[T]) *DelayQueue[T] {
+	d := &DelayQueue[T]{
+		q:                           queue.NewPriorityQueue[T](0, compare),
+		mutex:                       &sync.RWMutex{},
+		headOfQueueHasChangedSignal: make(chan struct{}),
+	}
+	return d
+}
+
+func (d *DelayQueue[T]) Enqueue(ctx context.Context, t T) error {
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	d.mutex.Lock()
+
+	// 排队超时
+	if ctx.Err() != nil {
+		d.mutex.Unlock()
+		return ctx.Err()
+	}
+
+	// 无界队列，不会返回err
+	_ = d.q.Enqueue(t)
+
+	// 写锁保护，刚刚入队，一定能拿到
+	head, _ := d.q.Peek()
+
+	// 元素t具有相等或更高优先级，等于0为了兼容队列为空的情况
+	if d.compareFunc(t, head) <= 0 {
+		atomic.AddInt64(&d.SignalSenders, 1)
+		defer atomic.AddInt64(&d.SignalSenders, -1)
+	}
+
+	d.mutex.Unlock()
+
+	trySendSignalCounter := 0
+	// 有并发协程调用Dequeue才需要发送信号
+	// 发送原则是：尽最大努力发送信号，不要永久阻塞自己，因为当Dequeue上的并发协程数大于队列中元素数还是有会阻塞的
+	// 同一时间段内排队的协程中，只有最后一个协程才有资格发送信号，记作：g10
+	// 下一时间段内排队的协程中，g20有资格发送信号，但因g10的存在而无法发送信号进而直接退出
+	if atomic.LoadInt64(&d.SignalReceivers) > 0 && atomic.LoadInt64(&d.SignalSenders) == 1 {
+		// 当g10执行到这里，d.wakeUpSignal缓冲区为0，恰好阻塞在Dequeue中select上的协程走case <-d.wakeUpSignal分支，g10退出
+		// 当g30执行到这里，d.wakeUpSignal缓冲区为0，恰好阻塞在Dequeue中select上的协程走其他case，此时
+		//   如果设置了超时，g30将在超时时间内，尽最大努力发送信号
+		//   如果未设置超时，g30将在尝试一定次数之后退出。
+		select {
+		case <-ctx.Done():
+			// g30因超时离开
+			return ctx.Err()
+		case d.headOfQueueHasChangedSignal <- struct{}{}:
+			// g10或g30因发送信号成功而离开
+			return nil
+		default:
+			trySendSignalCounter++
+			if trySendSignalCounter == 10 {
+				// g30因达到最大尝试次数而离开
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+type Cond struct {
+	sync.Cond
+}
+
+func (d *DelayQueue[T]) Dequeue(ctx context.Context) (T, error) {
+
+	atomic.AddInt64(&d.SignalReceivers, 1)
+	defer atomic.AddInt64(&d.SignalReceivers, -1)
+
+	var zeroValue T
+
+	// 过期超时
+	if ctx.Err() != nil {
+		return zeroValue, ctx.Err()
+	}
+
+	ticker := time.NewTicker(0)
+	ticker.Stop()
+
+	for {
+
+		d.mutex.Lock()
+
+		// 排队超时
+		if ctx.Err() != nil {
+			d.mutex.Unlock()
+			return zeroValue, ctx.Err()
+		}
+
+		head, err := d.q.Peek()
+
+		d.mutex.Unlock()
+
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return zeroValue, ctx.Err()
+			case <-d.headOfQueueHasChangedSignal:
+			}
+			continue
+		}
+
+		// todo: head是指针还是其他类型，如果head是指针，那么head可能已经被出队
+		duration := head.Delay() - time.Duration(time.Now().UnixNano())
+		if duration <= 0 {
+			continue
+		}
+
+		ticker.Reset(duration)
+
+		select {
+		case <-d.headOfQueueHasChangedSignal:
+			// 最坏情况，多个协程阻塞，从大到小一次入队，100s，50s, 25s, 12, 6, 3, 1
+			// 只唤醒一个，去队头重新取元素
+		case <-ctx.Done():
+			return zeroValue, ctx.Err()
+		case <-ticker.C:
+			d.mutex.Lock()
+			// 再次检查队头
+			// 1）此时恰好有更高优先级的元素入队，对延迟队列逻辑语义无影响，可以直接出队。
+			// 2）原队头被前一个协程拿走，而新队头与原队头之间较大时间差，不能直接出队。
+			//    当前协程需要再次阻塞，可能会出现饿死的情况。
+			head, err := d.q.Peek()
+			if err == nil {
+				// 验证队头元素确实过期
+				duration := head.Delay() - time.Duration(time.Now().UnixNano())
+				if duration <= 0 {
+					// 一定成功
+					t, err := d.q.Dequeue()
+					d.mutex.Unlock()
+					return t, err
+				}
+				// todo：优化点
+				//   协程经历过X次阻塞后，且duration大于0且小于阀值Y，在不释放写锁的情况下直接阻塞让其拿到队头
+				//   以解决饿死的问题
+			}
+			d.mutex.Unlock()
+			// 程序走到这，表示原队头被拿走，需要再次去队头
+		}
+	}
+}

--- a/queue/delay_queue.go
+++ b/queue/delay_queue.go
@@ -2,6 +2,9 @@ package queue
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -10,30 +13,120 @@ import (
 	"github.com/gotomicro/ekit/internal/queue"
 )
 
+var (
+	errInvalidArgument = errors.New("ekit: 参数非法")
+)
+
 type Delayable[T any] interface {
 	Delay() time.Duration
 }
 
 type DelayQueue[T Delayable[T]] struct {
-	q     *queue.PriorityQueue[T]
-	mutex *sync.RWMutex
+	mutex                *sync.RWMutex
+	q                    *queue.PriorityQueue[T]
+	capacity             int
+	compareFuncOfElement ekit.Comparator[T]
 
-	compareFunc ekit.Comparator[T]
+	// Enqueue方法上并发调用者协程计数
+	enqueueMutex   *sync.Mutex
+	enqueueCallers int64
 
-	headOfQueueHasChangedSignal chan struct{}
-	SignalSenders               int64
+	// enqueueProxy 协程相关
+	numOfEnqueueProxyGo         int64
+	newElementsChan             chan T
+	enqueueErrorChan            chan error
+	quitSignalForEnqueueProxy   chan struct{}
+	syncSignalFromEnqueueProxy  chan struct{}
+	wakeupSignalForEnqueueProxy chan struct{}
 
-	SignalReceivers int64
+	// Dequeue方法上并发调用者协程计数
+	dequeueMutex   *sync.Mutex
+	dequeueCallers int64
+
+	// dequeueProxy 协程相关
+	numOfDequeueProxyGo         int64
+	expiredElements             chan T
+	quitSignalForDequeueProxy   chan struct{}
+	syncSignalFromDequeueProxy  chan struct{}
+	wakeupSignalForDequeueProxy chan struct{}
 }
 
-func NewDelayQueue[T Delayable[T]](compare ekit.Comparator[T]) *DelayQueue[T] {
-	d := &DelayQueue[T]{
-		q:                           queue.NewPriorityQueue[T](0, compare),
-		mutex:                       &sync.RWMutex{},
-		headOfQueueHasChangedSignal: make(chan struct{}),
+func NewDelayQueue[T Delayable[T]](capacity int, compare ekit.Comparator[T]) (*DelayQueue[T], error) {
+	if capacity <= 0 {
+		return nil, fmt.Errorf("%w: capacity必须大于0", errInvalidArgument)
 	}
-	return d
+	if compare == nil {
+		return nil, fmt.Errorf("%w: compare不能为nil", errInvalidArgument)
+	}
+	d := &DelayQueue[T]{
+		mutex:                &sync.RWMutex{},
+		q:                    queue.NewPriorityQueue[T](capacity, compare),
+		capacity:             capacity,
+		compareFuncOfElement: compare,
+
+		enqueueMutex: &sync.Mutex{},
+		// enqueueProxy
+		newElementsChan:             make(chan T),
+		enqueueErrorChan:            make(chan error),
+		wakeupSignalForEnqueueProxy: make(chan struct{}, 1),
+		quitSignalForEnqueueProxy:   make(chan struct{}, 1),
+		syncSignalFromEnqueueProxy:  make(chan struct{}, 1),
+
+		dequeueMutex: &sync.Mutex{},
+		// dequeueProxy
+		// expiredElements 必须有缓冲区
+		expiredElements:             make(chan T, capacity),
+		wakeupSignalForDequeueProxy: make(chan struct{}, 1),
+		quitSignalForDequeueProxy:   make(chan struct{}, 1),
+		syncSignalFromDequeueProxy:  make(chan struct{}, 1),
+	}
+	return d, nil
 }
+
+/*
+
+g1  - \
+g2  - - Enqueue() -- N --> channel（多个通道） -- 1 --> enqueueProxy 协程 --
+g3  - /                                                                   \
+                                                     两个代理协程之间通过互斥锁、通道协作，详见下方说明3
+g4  - \                                                                   /
+g5  - - Dequeue() -- N --> channel（多个通道）-- 1 --> dequeueProxy 协程 --
+g6  - /
+
+说明：
+   1. g1、g2、g3并发调用Enqueue方法，Enqueue方法内部启动一个代理协程 enqueueProxy，
+      - enqueueProxy 职责
+        - 从调用者协程们接收数据
+        - 与下方 dequeueProxy 协程并发访问底层无锁优先级队列，将收到的数据入队
+        - 将入队结果返回给调用者协程们
+        - 如果有高优先级元素入队，导致队头变更，向 d.wakeupSignalForDequeueProxy 发信号通知下方 dequeueProxy 协程
+        - 监听退出信号，来自最后一个调用者协程发送的退出信号
+      - g1、g2、g3 通过channel与 enqueueProxy 协程通信
+        - 调用协程们通过 d.newElementsChan 向 enqueueProxy 发送数据
+        - 调用协程们通过 d.enqueueErrorChan 从 enqueueProxy 接收错误信息
+        - 第一/最后一个调用协程通过 d.quitSignalForEnqueueProxy 和 d.syncSignalFromEnqueueProxy 启动/关闭 enqueueProxy 协程
+          非并发，g1既是第一个又是最后一个需要负责启动和关闭 enqueueProxy
+          并发下，g1负责启动 enqueueProxy，g3 负责关闭 enqueueProxy
+
+   2. g3、g4、g5并发调用Dequeue方法，Dequeue方法内部启动一个代理协程 dequeueProxy，
+      - dequeueProxy 职责
+        - 获取队头，等待其过期；
+		- 与上方 enqueueProxy 协程并发访问底层无锁优先级队列，将过期队头出队
+        - 将出队结果返回给调用者协程们
+        - 监听唤醒信号，来自 enqueueProxy 协程，重新检查队头
+        - 监听退出信号，来自最后一个调用者协程发送的退出信号
+      - g3、g4、g5 通过channel与 DequeueProxy 协程通信
+        - 调用者协程们从 d.expiredElements 获取过期元素
+        - dequeueProxy 协程通过 d.wakeupSignalForDequeueProxy 获取通知以重新检查队头
+        - 第一/最后一个调用协程通过 d.quitSignalForDequeueProxy 和 d.syncSignalFromDequeueProxy 启动/关闭 dequeueProxy 协程
+        - Dequeue的逻辑语义是"拿到队头，等待队头超时或自己超时返回; 拿不到队头，阻塞等待直到ctx过期"
+          故Dequeue不返回延迟队列为空的错误，而是让调用者阻塞等待ctx超时；如果调用者未传递具有超时的ctx，导致永久阻塞是他自己的问题
+
+   3. enqueueProxy 与 dequeueProxy 协程之间通过互斥锁、通道来协作
+     - 用 d.mutex 并发操作底层优先级队列 d.q
+     - 用 d.wakeupSignalForDequeueProxy && d.wakeupSignalForEnqueueProxy 在队列状态变化时相互唤醒
+     - 无锁队列 d.q 上只有 enqueueProxy 与 dequeueProxy 两个协程并发访问
+*/
 
 func (d *DelayQueue[T]) Enqueue(ctx context.Context, t T) error {
 
@@ -41,134 +134,287 @@ func (d *DelayQueue[T]) Enqueue(ctx context.Context, t T) error {
 		return ctx.Err()
 	}
 
-	d.mutex.Lock()
-
-	// 排队超时
-	if ctx.Err() != nil {
-		d.mutex.Unlock()
-		return ctx.Err()
+	d.enqueueMutex.Lock()
+	// 更新计数与启动 enqueueProxy 协程必须是原子的
+	d.enqueueCallers++
+	// todo: 防止 enqueueProxy 协程中途panic退出
+	//       可以使用 atomic.LoadInt64(&d.numOfEnqueueProxyGo) == 0 作为启动 enqueueProxy 协程的条件
+	//       即在第一个检测到 enqueueProxy 协程没有启动的协程在进入下方select前，需要将 enqueueProxy 协程启动起来
+	// 第一个调用者负责启动 enqueueProxy 协程，在第一个调用者进入下方select语言前 enqueueProxy 必须启动
+	// 启动 enqueueProxy 协程后，阻塞等待
+	if d.enqueueCallers == 1 {
+		go d.enqueueProxy()
+		// enqueueProxy 协程启动后，唤醒当前协程
+		<-d.syncSignalFromEnqueueProxy
 	}
+	d.enqueueMutex.Unlock()
 
-	// 无界队列，不会返回err
-	_ = d.q.Enqueue(t)
-
-	// 写锁保护，刚刚入队，一定能拿到
-	head, _ := d.q.Peek()
-
-	// 元素t具有相等或更高优先级，等于0为了兼容队列为空的情况
-	if d.compareFunc(t, head) <= 0 {
-		atomic.AddInt64(&d.SignalSenders, 1)
-		defer atomic.AddInt64(&d.SignalSenders, -1)
-	}
-
-	d.mutex.Unlock()
-
-	trySendSignalCounter := 0
-	// 有并发协程调用Dequeue才需要发送信号
-	// 发送原则是：尽最大努力发送信号，不要永久阻塞自己，因为当Dequeue上的并发协程数大于队列中元素数还是有会阻塞的
-	// 同一时间段内排队的协程中，只有最后一个协程才有资格发送信号，记作：g10
-	// 下一时间段内排队的协程中，g20有资格发送信号，但因g10的存在而无法发送信号进而直接退出
-	if atomic.LoadInt64(&d.SignalReceivers) > 0 && atomic.LoadInt64(&d.SignalSenders) == 1 {
-		// 当g10执行到这里，d.wakeUpSignal缓冲区为0，恰好阻塞在Dequeue中select上的协程走case <-d.wakeUpSignal分支，g10退出
-		// 当g30执行到这里，d.wakeUpSignal缓冲区为0，恰好阻塞在Dequeue中select上的协程走其他case，此时
-		//   如果设置了超时，g30将在超时时间内，尽最大努力发送信号
-		//   如果未设置超时，g30将在尝试一定次数之后退出。
-		select {
-		case <-ctx.Done():
-			// g30因超时离开
-			return ctx.Err()
-		case d.headOfQueueHasChangedSignal <- struct{}{}:
-			// g10或g30因发送信号成功而离开
-			return nil
-		default:
-			trySendSignalCounter++
-			if trySendSignalCounter == 10 {
-				// g30因达到最大尝试次数而离开
-				return nil
-			}
+	defer func() {
+		d.enqueueMutex.Lock()
+		// 更新计数与发送信号必须是原子的
+		d.enqueueCallers--
+		// 最后一个调用者通知 enqueueProxy 退出，在最后一个调用者退出前 enqueueProxy 必须退出
+		// todo: 防止 enqueueProxy 协程中途 panic 退出
+		//       可以使用 d.enqueueCallers == 0 && atomic.LoadInt64(&d.numOfEnqueueProxyGo) == 1 作为通知 enqueueProxy 协程退出的条件
+		//       即最后一个检测到 enqueueProxy 协程存在的协程，在退出前需要确保 enqueueProxy 协程先于自己退出。
+		if d.enqueueCallers == 0 {
+			// 以非阻塞方式发送信号，通知 enqueueProxy 协程走退出流程，当前协程阻塞等待
+			d.quitSignalForEnqueueProxy <- struct{}{}
+			// enqueueProxy 协程退出前，通知当前协程退出
+			<-d.syncSignalFromEnqueueProxy
 		}
+		d.enqueueMutex.Unlock()
+	}()
+
+	log.Println("Enqueue, Waiting for adding element....")
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case d.newElementsChan <- t:
+		return <-d.enqueueErrorChan
 	}
-	return nil
 }
 
-type Cond struct {
-	sync.Cond
+func (d *DelayQueue[T]) enqueueProxy() {
+
+	defer func() {
+		atomic.CompareAndSwapInt64(&d.numOfEnqueueProxyGo, 1, 0)
+		// todo: recover 防止未知panic
+		// 发送退出信号，信号一定要在计数更新后发送
+		d.syncSignalFromEnqueueProxy <- struct{}{}
+		log.Println("enqueueProxy stop....")
+	}()
+
+	// 发送启动信号，信号一个要在计数更新后发送
+	atomic.CompareAndSwapInt64(&d.numOfEnqueueProxyGo, 0, 1)
+	d.syncSignalFromEnqueueProxy <- struct{}{}
+
+	log.Println("enqueueProxy start....")
+
+	for {
+
+		select {
+		case e := <-d.newElementsChan:
+			log.Println("enqueueProxy, get element ", e)
+
+			d.mutex.Lock()
+
+			// 队列已满
+			// dequeueProxy 协程在向 d.expiredElements 发送数据时
+			// 需要先加写锁再执行 d.q.Dequeue 最后再发送
+			// 所以len( d.expiredElements ) 可以认为保持不变
+			isFull := d.q.Len()+len(d.expiredElements) == d.capacity
+			if isFull {
+				d.mutex.Unlock()
+				log.Println("enqueueProxy, send err == Full ... ")
+				// 通知当前 Enqueue 协程队列已满
+				d.enqueueErrorChan <- queue.ErrOutOfCapacity
+				log.Println("enqueueProxy, blocking... ")
+				continue
+			}
+			// todo: 优化为 d.newElementsChan 设置缓冲区，拿到一次锁尽可能将缓冲区中数据全部Enqueue
+			//       需要注意容量判断问题，上方 isFull
+			err := d.q.Enqueue(e)
+			if err != nil {
+				// 队列已满
+				d.mutex.Unlock()
+				log.Println("enqueueProxy, send err == Full ... ")
+				d.enqueueErrorChan <- queue.ErrOutOfCapacity
+				log.Println("enqueueProxy, blocking... ")
+				continue
+			}
+			// 写锁保护中，刚入队成功，一定能拿到
+			head, _ := d.q.Peek()
+			// 新入队元素e具有相等或更高优先级，等于0为了兼容队列为空的情况
+			headOfQueueHasChanged := d.compareFuncOfElement(e, head) <= 0
+			// d.wakeupSignalForDequeueProxy 的消费者只有 dequeueProxy 协程
+			// 只有 d.wakeupSignalForDequeueProxy 为空时才需要再次发送信号
+			// 如果之前的信号还未被 dequeueProxy 协程消费，未消费的信号也能表示相同意义
+			// 即 dequeueProxy 协程拿到信号后，重新去检查队头且此时新队头就是刚刚入队元素e
+			thereIsNoUnreceivedWakeupSignal := len(d.wakeupSignalForDequeueProxy) == 0
+
+			if headOfQueueHasChanged && thereIsNoUnreceivedWakeupSignal {
+				d.wakeupSignalForDequeueProxy <- struct{}{}
+				log.Println("enqueueProxy, notify dequeueProxy ... ")
+			}
+			d.mutex.Unlock()
+
+			// 通知 Enqueue 协程入队成功
+			d.enqueueErrorChan <- (error)(nil)
+			log.Println("enqueueProxy, send err == nil , element enqueued ....", e, "len = ", d.Len())
+
+		case <-d.quitSignalForEnqueueProxy:
+			return
+		case <-d.wakeupSignalForEnqueueProxy:
+			// 等待 dequeueProxy 在调用 d.q.Dequeue 后发送信号将自己唤醒
+			log.Println("enqueueProxy, wakeup by dequeueProxy ... ")
+		}
+	}
 }
 
 func (d *DelayQueue[T]) Dequeue(ctx context.Context) (T, error) {
 
-	atomic.AddInt64(&d.SignalReceivers, 1)
-	defer atomic.AddInt64(&d.SignalReceivers, -1)
-
 	var zeroValue T
-
-	// 过期超时
 	if ctx.Err() != nil {
 		return zeroValue, ctx.Err()
 	}
 
-	ticker := time.NewTicker(0)
-	ticker.Stop()
+	d.dequeueMutex.Lock()
+	// 跟新计数与启动 dequeueProxy 协程必须是原子的
+	d.dequeueCallers++
+	// 第一个调用者负责启动 dequeueProxy 协程，在第一个调用者进入下方select语言前 dequeueProxy 必须启动
+	// todo: 防止 dequeueProxy 协程中途 panic 退出
+	//       可以使用 atomic.LoadInt64(&d.numOfDequeueProxyGo) == 0 作为启动 dequeueProxy 协程的条件
+	//       即在第一个检测到 dequeueProxy 协程没有启动的协程进入下方select前，需要将 dequeueProxy 协程启动起来
+	if d.dequeueCallers == 1 {
+		// 启动 dequeueProxy 协程后，阻塞等待
+		go d.dequeueProxy()
+		// dequeueProxy 协程启动后，唤醒当前协程
+		<-d.syncSignalFromDequeueProxy
+	}
+	d.dequeueMutex.Unlock()
+
+	defer func() {
+		d.dequeueMutex.Lock()
+		// 更新计数与发送信号必须是原子的
+		d.dequeueCallers--
+		// 最后一个调用者通知 dequeueProxy 退出，在最后一个调用者退出前 dequeueProxy 必须退出
+		// todo: 防止 dequeueProxy 协程中途panic退出
+		//       可以使用 d.dequeueCallers == 0 && atomic.LoadInt64(&d.numOfDequeueProxyGo) == 1 作为通知 dequeueProxy 协程退出的条件
+		//       即最后一个检测到 dequeueProxy 协程存在的协程，在退出前需要确保 dequeueProxy 协程先于自己退出。
+		if d.dequeueCallers == 0 {
+			// 以非阻塞方式发送信号，通知poller协程走退出流程，当前协程阻塞等待
+			d.quitSignalForDequeueProxy <- struct{}{}
+			// poller协程退出前，通知当前协程退出
+			<-d.syncSignalFromDequeueProxy
+		}
+		d.dequeueMutex.Unlock()
+	}()
+
+	log.Println("Dequeue, Waiting for element....")
+
+	select {
+	case <-ctx.Done():
+		return zeroValue, ctx.Err()
+	case elem := <-d.expiredElements:
+		log.Println("Dequeue ...", elem)
+		return elem, nil
+	}
+}
+
+func (d *DelayQueue[T]) dequeueProxy() {
+
+	defer func() {
+		atomic.CompareAndSwapInt64(&d.numOfDequeueProxyGo, 1, 0)
+		// todo: recover防止未知panic
+		// 发送退出信号，信号一定要在计数更新后发送
+		d.syncSignalFromDequeueProxy <- struct{}{}
+		log.Println("dequeueProxy stop....")
+	}()
+
+	atomic.CompareAndSwapInt64(&d.numOfDequeueProxyGo, 0, 1)
+	log.Println("dequeueProxy start....")
+	// 发送启动信号，信号一个要在计数更新后发送
+	d.syncSignalFromDequeueProxy <- struct{}{}
+
+	defaultBlockingDuration := time.Hour
+	ticker := time.NewTicker(defaultBlockingDuration)
+
+	var remainingBlockingDuration time.Duration
 
 	for {
-
-		d.mutex.Lock()
-
-		// 排队超时
-		if ctx.Err() != nil {
-			d.mutex.Unlock()
-			return zeroValue, ctx.Err()
-		}
-
+		log.Println("dequeueProxy, peek before....")
+		d.mutex.RLock()
 		head, err := d.q.Peek()
+		d.mutex.RUnlock()
+		log.Println("dequeueProxy, peek after....")
 
-		d.mutex.Unlock()
-
+		// 队列为空
 		if err != nil {
-			select {
-			case <-ctx.Done():
-				return zeroValue, ctx.Err()
-			case <-d.headOfQueueHasChangedSignal:
-			}
+			log.Println("dequeueProxy, blocking before, queue empty....")
+			ticker.Reset(defaultBlockingDuration)
+			goto blocking
+		}
+
+		remainingBlockingDuration = head.Delay() - time.Duration(time.Now().Unix())
+		if remainingBlockingDuration > 0 {
+			// 数据未过期
+			log.Println("dequeueProxy, blocking before, waiting duration ....", head, remainingBlockingDuration, time.Now())
+			ticker.Reset(remainingBlockingDuration)
+			goto blocking
+		} else {
+			// 数据已过期
+			log.Println("dequeueProxy, send before....")
+			d.dequeueAndSendExpiredElement()
+			log.Println("dequeueProxy, send after....")
+			// 重新获取队头
 			continue
 		}
 
-		// todo: head是指针还是其他类型，如果head是指针，那么head可能已经被出队
-		duration := head.Delay() - time.Duration(time.Now().UnixNano())
-		if duration <= 0 {
-			continue
-		}
-
-		ticker.Reset(duration)
-
+	blocking:
+		log.Println("dequeueProxy, blocking....")
 		select {
-		case <-d.headOfQueueHasChangedSignal:
-			// 最坏情况，多个协程阻塞，从大到小一次入队，100s，50s, 25s, 12, 6, 3, 1
-			// 只唤醒一个，去队头重新取元素
-		case <-ctx.Done():
-			return zeroValue, ctx.Err()
+		case <-d.quitSignalForDequeueProxy:
+			return
 		case <-ticker.C:
-			d.mutex.Lock()
-			// 再次检查队头
-			// 1）此时恰好有更高优先级的元素入队，对延迟队列逻辑语义无影响，可以直接出队。
-			// 2）原队头被前一个协程拿走，而新队头与原队头之间较大时间差，不能直接出队。
-			//    当前协程需要再次阻塞，可能会出现饿死的情况。
-			head, err := d.q.Peek()
-			if err == nil {
-				// 验证队头元素确实过期
-				duration := head.Delay() - time.Duration(time.Now().UnixNano())
-				if duration <= 0 {
-					// 一定成功
-					t, err := d.q.Dequeue()
-					d.mutex.Unlock()
-					return t, err
-				}
-				// todo：优化点
-				//   协程经历过X次阻塞后，且duration大于0且小于阀值Y，在不释放写锁的情况下直接阻塞让其拿到队头
-				//   以解决饿死的问题
-			}
-			d.mutex.Unlock()
-			// 程序走到这，表示原队头被拿走，需要再次去队头
+			// 因为只有poller协程调用d.q.Dequeue()
+			// 阻塞醒来后是可以立即调用d.q.Dequeue()，即便与b.q.Enqueue()并发也是正确的。
+			// 不存在原队头被其他协程并发调用d.q.Dequeue()出队的情况(不允许出现多poller实例的情况）
+			// 为了便于理解程序，将下方调用代码注释，不注释下方调用的逻辑分析见方法内部注释
+			// d.dequeueAndSendExpiredElement()
+			log.Println("dequeueProxy, unblocked by Ticker.....")
+		case <-d.wakeupSignalForDequeueProxy:
+			// 队头更新，再次检查
+			log.Println("dequeueProxy, unblocked by Signal.....")
 		}
 	}
+}
+
+func (d *DelayQueue[T]) dequeueAndSendExpiredElement() {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	// 前置条件：单 dequeueProxy 协程实例
+
+	// 如果不注释掉 dequeueProxy 中case <-ticker.C下的本方法调用，在单 dequeueProxy 实例的前提下，程序执行到这里有两种情况：
+	// Case 1. 队头元素X过期，直接出队元素X
+	// Case 2. 协程按原队头X的 remainingBlockingDuration 阻塞中：
+	// 	        A. 阻塞到期后，执行d.q.Dequeue()删除原队头X
+	// 	        B. 收到新元素Y入队的信号，重新去队头获取阻塞时间duration
+	//             1) 如果已过期duration <= 0，直接将新队头出队（即重复[Case 1]操作）此时出队的是新队头Y
+	//             2) 如果还需阻塞，重复[Case 2.A]操作，此时出队的也是新队头Y
+	//             3) 如果有新元素入队，此时重复[Case 2.B]操作
+	// 通过以上分析可知，无论d.q.Dequeue()出队的是原队头X还是新队头Y/Z/M等(多次插队），因插队元素相比于原队头具有更高或相等的优先级
+	// 那么即便按照原队头的remainingBlockingDuration进行阻塞且被唤醒后直接d.q.Dequeue()删除的是新队头也是安全。
+	// 因为新队头的截止日期应该早于或等原队头的截止日期。
+
+	// 如果注释掉 dequeueProxy 中case <-ticker.C下的本方法调用，在单 dequeueProxy 实例的前提下，进入这里只有一种情况：remainingBlockingDuration <= 0
+
+	// 单 dequeueProxy 协程下，一定没问题
+	// 多 dequeueProxy 协程下，要检查当前队头与阻塞前获取的队头是一样的，不一样要
+	expired, _ := d.q.Dequeue()
+
+	// 非阻塞
+	// 即便此时 dequeueProxy 协程收到退出信号,因 d.expiredElements 有缓冲区且与 d.q 的容量相同
+	// 因此过期的数据会缓存在 d.expiredElements 中后续调用Dequeue的协程可以直接拿到
+	// 注意: d.expiredElements 一定要有缓冲，
+	// 否则唯一的Dequeue调用者协程因ctx超时走退出流程时，
+	// Dequeue 调用者协程等待在 d.quitSignalForDequeueProxy 上而 dequeueProxy 协程等待在 d.expiredElements <- expired 上从而形成两者相互等待
+	d.expiredElements <- expired
+	log.Println("dequeueProxy, element dequeued .... ", expired, d.q.Len())
+
+	// 之前容量为满，enqueueProxy 可能被阻塞
+	enqueueProxyMayBeBlocked := d.q.Len()+len(d.expiredElements) == d.capacity
+	thereIsNoUnreceivedWakeupSignal := len(d.wakeupSignalForEnqueueProxy) == 0
+	if enqueueProxyMayBeBlocked && thereIsNoUnreceivedWakeupSignal {
+		d.wakeupSignalForEnqueueProxy <- struct{}{}
+	}
+}
+
+func (d *DelayQueue[T]) Len() int {
+	d.mutex.RLock()
+	// 一部分过期数据会缓存在 expiredElements 中
+	// 但并未被Dequeue调用协程取走，所以逻辑上还是要将缓存数据算在内的。
+	n := d.q.Len() + len(d.expiredElements)
+	d.mutex.RUnlock()
+	return n
 }

--- a/queue/delay_queue.go
+++ b/queue/delay_queue.go
@@ -1,10 +1,23 @@
+// Copyright 2021 gotomicro
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package queue
 
 import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -13,14 +26,58 @@ import (
 	"github.com/gotomicro/ekit/internal/queue"
 )
 
+// g1  - \
+// g2  - - Enqueue() -- N --> channel（多个通道） -- 1 --> enqueueProxy 协程 --
+// g3  - /                                                                   \
+//                                                      两个代理协程之间通过互斥锁、通道协作，详见下方说明3
+// g4  - \                                                                   /
+// g5  - - Dequeue() -- N --> channel（多个通道）-- 1 --> dequeueProxy 协程 --
+// g6  - /
+//
+// 说明：
+//    1. g1、g2、g3并发调用Enqueue方法，Enqueue方法内部启动一个代理协程 enqueueProxy，
+//       - enqueueProxy 职责
+//         - 从调用者协程们接收数据
+//         - 与下方 dequeueProxy 协程并发访问底层无锁优先级队列，将收到的数据入队
+//         - 将入队结果返回给调用者协程们
+//         - 如果有高优先级元素入队，导致队头变更，向 d.wakeupSignalForDequeueProxy 发信号通知下方 dequeueProxy 协程
+//         - 监听退出信号，来自最后一个调用者协程发送的退出信号
+//       - g1、g2、g3 通过channel与 enqueueProxy 协程通信
+//         - 调用协程们通过 d.newElementsChan 向 enqueueProxy 发送数据
+//         - 调用协程们通过 d.enqueueErrorChan 从 enqueueProxy 接收错误信息
+//         - 第一/最后一个调用协程通过 d.quitSignalForEnqueueProxy 和 d.continueSignalFromEnqueueProxy 启动/关闭 enqueueProxy 协程
+//           非并发，g1既是第一个又是最后一个需要负责启动和关闭 enqueueProxy
+//           并发下，g1负责启动 enqueueProxy，g3 负责关闭 enqueueProxy
+//
+//    2. g3、g4、g5并发调用Dequeue方法，Dequeue方法内部启动一个代理协程 dequeueProxy，
+//       - dequeueProxy 职责
+//         - 获取队头，等待其过期；
+// 		- 与上方 enqueueProxy 协程并发访问底层无锁优先级队列，将过期队头出队
+//         - 将出队结果返回给调用者协程们
+//         - 监听唤醒信号，来自 enqueueProxy 协程，重新检查队头
+//         - 监听退出信号，来自最后一个调用者协程发送的退出信号
+//       - g3、g4、g5 通过channel与 DequeueProxy 协程通信
+//         - 调用者协程们从 d.expiredElements 获取过期元素
+//         - dequeueProxy 协程通过 d.wakeupSignalForDequeueProxy 获取通知以重新检查队头
+//         - 第一/最后一个调用协程通过 d.quitSignalForDequeueProxy 和 d.continueSignalFromDequeueProxy 启动/关闭 dequeueProxy 协程
+//         - Dequeue的逻辑语义是"拿到队头，等待队头超时或自己超时返回; 拿不到队头，阻塞等待直到ctx过期"
+//           故Dequeue不返回延迟队列为空的错误，而是让调用者阻塞等待ctx超时；如果调用者未传递具有超时的ctx，导致永久阻塞是他自己的问题
+//
+//    3. enqueueProxy 与 dequeueProxy 协程之间通过互斥锁、通道来协作
+//      - 用 d.mutex 并发操作底层优先级队列 d.q
+//      - 用 d.wakeupSignalForDequeueProxy && d.wakeupSignalForEnqueueProxy 在队列状态变化时相互唤醒
+//      - 无锁队列 d.q 上只有 enqueueProxy 与 dequeueProxy 两个协程并发访问
+
 var (
 	errInvalidArgument = errors.New("ekit: 参数非法")
 )
 
+// Delayable 入队元素需要实现接口中的 Deadline 方法
 type Delayable[T any] interface {
 	Deadline() time.Time
 }
 
+// DelayQueue 并发延迟队列
 type DelayQueue[T Delayable[T]] struct {
 	mutex                *sync.RWMutex
 	q                    *queue.PriorityQueue[T]
@@ -32,23 +89,23 @@ type DelayQueue[T Delayable[T]] struct {
 	enqueueCallers int64
 
 	// enqueueProxy 协程相关
-	numOfEnqueueProxyGo         int64
-	newElementsChan             chan T
-	enqueueErrorChan            chan error
-	quitSignalForEnqueueProxy   chan struct{}
-	syncSignalFromEnqueueProxy  chan struct{}
-	wakeupSignalForEnqueueProxy chan struct{}
+	numOfEnqueueProxyGo            int64
+	newElementsChan                chan T
+	enqueueErrorChan               chan error
+	quitSignalForEnqueueProxy      chan struct{}
+	continueSignalFromEnqueueProxy chan struct{}
+	wakeupSignalForEnqueueProxy    chan struct{}
 
 	// Dequeue方法上并发调用者协程计数
 	dequeueMutex   *sync.Mutex
 	dequeueCallers int64
 
 	// dequeueProxy 协程相关
-	numOfDequeueProxyGo         int64
-	expiredElements             chan T
-	quitSignalForDequeueProxy   chan struct{}
-	syncSignalFromDequeueProxy  chan struct{}
-	wakeupSignalForDequeueProxy chan struct{}
+	numOfDequeueProxyGo            int64
+	expiredElements                chan T
+	quitSignalForDequeueProxy      chan struct{}
+	continueSignalFromDequeueProxy chan struct{}
+	wakeupSignalForDequeueProxy    chan struct{}
 }
 
 func NewDelayQueue[T Delayable[T]](capacity int, compare ekit.Comparator[T]) (*DelayQueue[T], error) {
@@ -66,67 +123,22 @@ func NewDelayQueue[T Delayable[T]](capacity int, compare ekit.Comparator[T]) (*D
 
 		enqueueMutex: &sync.Mutex{},
 		// enqueueProxy
-		newElementsChan:             make(chan T),
-		enqueueErrorChan:            make(chan error),
-		wakeupSignalForEnqueueProxy: make(chan struct{}, 1),
-		quitSignalForEnqueueProxy:   make(chan struct{}, 1),
-		syncSignalFromEnqueueProxy:  make(chan struct{}, 1),
+		newElementsChan:                make(chan T),
+		enqueueErrorChan:               make(chan error),
+		wakeupSignalForEnqueueProxy:    make(chan struct{}, 1),
+		quitSignalForEnqueueProxy:      make(chan struct{}, 1),
+		continueSignalFromEnqueueProxy: make(chan struct{}, 1),
 
 		dequeueMutex: &sync.Mutex{},
 		// dequeueProxy
 		// expiredElements 必须有缓冲区
-		expiredElements:             make(chan T, capacity),
-		wakeupSignalForDequeueProxy: make(chan struct{}, 1),
-		quitSignalForDequeueProxy:   make(chan struct{}, 1),
-		syncSignalFromDequeueProxy:  make(chan struct{}, 1),
+		expiredElements:                make(chan T, capacity),
+		wakeupSignalForDequeueProxy:    make(chan struct{}, 1),
+		quitSignalForDequeueProxy:      make(chan struct{}, 1),
+		continueSignalFromDequeueProxy: make(chan struct{}, 1),
 	}
 	return d, nil
 }
-
-/*
-
-g1  - \
-g2  - - Enqueue() -- N --> channel（多个通道） -- 1 --> enqueueProxy 协程 --
-g3  - /                                                                   \
-                                                     两个代理协程之间通过互斥锁、通道协作，详见下方说明3
-g4  - \                                                                   /
-g5  - - Dequeue() -- N --> channel（多个通道）-- 1 --> dequeueProxy 协程 --
-g6  - /
-
-说明：
-   1. g1、g2、g3并发调用Enqueue方法，Enqueue方法内部启动一个代理协程 enqueueProxy，
-      - enqueueProxy 职责
-        - 从调用者协程们接收数据
-        - 与下方 dequeueProxy 协程并发访问底层无锁优先级队列，将收到的数据入队
-        - 将入队结果返回给调用者协程们
-        - 如果有高优先级元素入队，导致队头变更，向 d.wakeupSignalForDequeueProxy 发信号通知下方 dequeueProxy 协程
-        - 监听退出信号，来自最后一个调用者协程发送的退出信号
-      - g1、g2、g3 通过channel与 enqueueProxy 协程通信
-        - 调用协程们通过 d.newElementsChan 向 enqueueProxy 发送数据
-        - 调用协程们通过 d.enqueueErrorChan 从 enqueueProxy 接收错误信息
-        - 第一/最后一个调用协程通过 d.quitSignalForEnqueueProxy 和 d.syncSignalFromEnqueueProxy 启动/关闭 enqueueProxy 协程
-          非并发，g1既是第一个又是最后一个需要负责启动和关闭 enqueueProxy
-          并发下，g1负责启动 enqueueProxy，g3 负责关闭 enqueueProxy
-
-   2. g3、g4、g5并发调用Dequeue方法，Dequeue方法内部启动一个代理协程 dequeueProxy，
-      - dequeueProxy 职责
-        - 获取队头，等待其过期；
-		- 与上方 enqueueProxy 协程并发访问底层无锁优先级队列，将过期队头出队
-        - 将出队结果返回给调用者协程们
-        - 监听唤醒信号，来自 enqueueProxy 协程，重新检查队头
-        - 监听退出信号，来自最后一个调用者协程发送的退出信号
-      - g3、g4、g5 通过channel与 DequeueProxy 协程通信
-        - 调用者协程们从 d.expiredElements 获取过期元素
-        - dequeueProxy 协程通过 d.wakeupSignalForDequeueProxy 获取通知以重新检查队头
-        - 第一/最后一个调用协程通过 d.quitSignalForDequeueProxy 和 d.syncSignalFromDequeueProxy 启动/关闭 dequeueProxy 协程
-        - Dequeue的逻辑语义是"拿到队头，等待队头超时或自己超时返回; 拿不到队头，阻塞等待直到ctx过期"
-          故Dequeue不返回延迟队列为空的错误，而是让调用者阻塞等待ctx超时；如果调用者未传递具有超时的ctx，导致永久阻塞是他自己的问题
-
-   3. enqueueProxy 与 dequeueProxy 协程之间通过互斥锁、通道来协作
-     - 用 d.mutex 并发操作底层优先级队列 d.q
-     - 用 d.wakeupSignalForDequeueProxy && d.wakeupSignalForEnqueueProxy 在队列状态变化时相互唤醒
-     - 无锁队列 d.q 上只有 enqueueProxy 与 dequeueProxy 两个协程并发访问
-*/
 
 func (d *DelayQueue[T]) Enqueue(ctx context.Context, t T) error {
 
@@ -134,39 +146,30 @@ func (d *DelayQueue[T]) Enqueue(ctx context.Context, t T) error {
 		return ctx.Err()
 	}
 
+	// 更新计数与启动/关闭 enqueueProxy 协程必须是原子的
 	d.enqueueMutex.Lock()
-	// 更新计数与启动 enqueueProxy 协程必须是原子的
 	d.enqueueCallers++
-	// todo: 防止 enqueueProxy 协程中途panic退出
-	//       可以使用 atomic.LoadInt64(&d.numOfEnqueueProxyGo) == 0 作为启动 enqueueProxy 协程的条件
-	//       即在第一个检测到 enqueueProxy 协程没有启动的协程在进入下方select前，需要将 enqueueProxy 协程启动起来
-	// 第一个调用者负责启动 enqueueProxy 协程，在第一个调用者进入下方select语言前 enqueueProxy 必须启动
-	// 启动 enqueueProxy 协程后，阻塞等待
-	if d.enqueueCallers == 1 {
+	// 第一个检测到 enqueueProxy 协程没启动的调用者负责启动 enqueueProxy 协程，调用者进入下方select语言前 enqueueProxy 必须启动
+	if atomic.LoadInt64(&d.numOfEnqueueProxyGo) == 0 {
 		go d.enqueueProxy()
-		// enqueueProxy 协程启动后，唤醒当前协程
-		<-d.syncSignalFromEnqueueProxy
+		// enqueueProxy 协程启动后，通知当前协程继续运行
+		<-d.continueSignalFromEnqueueProxy
 	}
 	d.enqueueMutex.Unlock()
 
 	defer func() {
 		d.enqueueMutex.Lock()
-		// 更新计数与发送信号必须是原子的
 		d.enqueueCallers--
-		// 最后一个调用者通知 enqueueProxy 退出，在最后一个调用者退出前 enqueueProxy 必须退出
-		// todo: 防止 enqueueProxy 协程中途 panic 退出
-		//       可以使用 d.enqueueCallers == 0 && atomic.LoadInt64(&d.numOfEnqueueProxyGo) == 1 作为通知 enqueueProxy 协程退出的条件
-		//       即最后一个检测到 enqueueProxy 协程存在的协程，在退出前需要确保 enqueueProxy 协程先于自己退出。
-		if d.enqueueCallers == 0 {
+		// 最后一个检测到 enqueueProxy 协程存在的调用者，在退出前需要确保 enqueueProxy 协程先于自己退出。
+		if d.enqueueCallers == 0 && atomic.LoadInt64(&d.numOfEnqueueProxyGo) == 1 {
 			// 以非阻塞方式发送信号，通知 enqueueProxy 协程走退出流程，当前协程阻塞等待
 			d.quitSignalForEnqueueProxy <- struct{}{}
-			// enqueueProxy 协程退出前，通知当前协程退出
-			<-d.syncSignalFromEnqueueProxy
+			<-d.continueSignalFromEnqueueProxy
 		}
 		d.enqueueMutex.Unlock()
 	}()
 
-	log.Println("Enqueue, Waiting for adding element....")
+	// log.Println("Enqueue, Waiting for adding element....")
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -178,51 +181,54 @@ func (d *DelayQueue[T]) Enqueue(ctx context.Context, t T) error {
 func (d *DelayQueue[T]) enqueueProxy() {
 
 	defer func() {
+		// 吞掉panic
+		_ = recover()
+		// 必须先更新计数，再发送信号
 		atomic.CompareAndSwapInt64(&d.numOfEnqueueProxyGo, 1, 0)
-		// todo: recover 防止未知panic
-		// 发送退出信号，信号一定要在计数更新后发送
-		d.syncSignalFromEnqueueProxy <- struct{}{}
-		log.Println("enqueueProxy stop....")
+		d.continueSignalFromEnqueueProxy <- struct{}{}
+		// log.Println("enqueueProxy stop....")
 	}()
 
-	// 发送启动信号，信号一个要在计数更新后发送
+	// 必须先更新计数，再发送信号
 	atomic.CompareAndSwapInt64(&d.numOfEnqueueProxyGo, 0, 1)
-	d.syncSignalFromEnqueueProxy <- struct{}{}
+	d.continueSignalFromEnqueueProxy <- struct{}{}
 
-	log.Println("enqueueProxy start....")
+	// log.Println("enqueueProxy start....")
 
 	for {
 
 		select {
 		case e := <-d.newElementsChan:
-			log.Println("enqueueProxy, get element ", e)
+			// log.Println("enqueueProxy, get element ", e)
 
 			d.mutex.Lock()
 
 			// 队列已满
 			// dequeueProxy 协程在向 d.expiredElements 发送数据时
-			// 需要先加写锁再执行 d.q.Dequeue 最后再发送
-			// 所以len( d.expiredElements ) 可以认为保持不变
+			// 即 d.dequeueAndSendExpiredElement() 中实现也用到了写锁
+			// 所以这里可以认为 len( d.expiredElements ) 不变
 			isFull := d.q.Len()+len(d.expiredElements) == d.capacity
 			if isFull {
 				d.mutex.Unlock()
-				log.Println("enqueueProxy, send err == Full ... ")
+				// log.Println("enqueueProxy, send err == Full ... ")
 				// 通知当前 Enqueue 协程队列已满
 				d.enqueueErrorChan <- queue.ErrOutOfCapacity
-				log.Println("enqueueProxy, blocking... ")
+				// log.Println("enqueueProxy, blocking... ")
 				continue
 			}
-			// todo: 优化为 d.newElementsChan 设置缓冲区，拿到一次锁尽可能将缓冲区中数据全部Enqueue
-			//       需要注意容量判断问题，上方 isFull
-			err := d.q.Enqueue(e)
-			if err != nil {
-				// 队列已满
-				d.mutex.Unlock()
-				log.Println("enqueueProxy, send err == Full ... ")
-				d.enqueueErrorChan <- queue.ErrOutOfCapacity
-				log.Println("enqueueProxy, blocking... ")
-				continue
-			}
+			// todo: 优化点：为 d.newElementsChan 设置缓冲区，拿到一次锁尽可能将缓冲区中数据全部Enqueue
+			//       需要注意容量判断问题，详见上方isFull
+			_ = d.q.Enqueue(e)
+			// err := d.q.Enqueue(e)
+			// if err != nil {
+			// 	// 队列已满
+			// 	d.mutex.Unlock()
+			// 	log.Println("enqueueProxy, send err == Full ... ")
+			// 	d.enqueueErrorChan <- queue.ErrOutOfCapacity
+			// 	log.Println("enqueueProxy, blocking... ")
+			// 	continue
+			// }
+
 			// 写锁保护中，刚入队成功，一定能拿到
 			head, _ := d.q.Peek()
 			// 新入队元素e具有相等或更高优先级，等于0为了兼容队列为空的情况
@@ -230,24 +236,24 @@ func (d *DelayQueue[T]) enqueueProxy() {
 			// d.wakeupSignalForDequeueProxy 的消费者只有 dequeueProxy 协程
 			// 只有 d.wakeupSignalForDequeueProxy 为空时才需要再次发送信号
 			// 如果之前的信号还未被 dequeueProxy 协程消费，未消费的信号也能表示相同意义
-			// 即 dequeueProxy 协程拿到信号后，重新去检查队头且此时新队头就是刚刚入队元素e
+			// 即 dequeueProxy 协程拿到信号后重新去检查队头
 			thereIsNoUnreceivedWakeupSignal := len(d.wakeupSignalForDequeueProxy) == 0
 
 			if headOfQueueHasChanged && thereIsNoUnreceivedWakeupSignal {
 				d.wakeupSignalForDequeueProxy <- struct{}{}
-				log.Println("enqueueProxy, notify dequeueProxy ... ")
+				// log.Println("enqueueProxy, notify dequeueProxy ... ")
 			}
 			d.mutex.Unlock()
 
 			// 通知 Enqueue 协程入队成功
 			d.enqueueErrorChan <- (error)(nil)
-			log.Println("enqueueProxy, send err == nil , element enqueued ....", e, "len = ", d.Len())
+			// log.Println("enqueueProxy, send err == nil , element enqueued ....", e, "len = ", d.Len())
 
 		case <-d.quitSignalForEnqueueProxy:
 			return
-		case <-d.wakeupSignalForEnqueueProxy:
-			// 等待 dequeueProxy 在调用 d.q.Dequeue 后发送信号将自己唤醒
-			log.Println("enqueueProxy, wakeup by dequeueProxy ... ")
+			// case <-d.wakeupSignalForEnqueueProxy:
+			// 	// 等待 dequeueProxy 在调用 d.q.Dequeue 后发送信号将自己唤醒
+			// 	log.Println("enqueueProxy, wakeup by dequeueProxy ... ")
 		}
 	}
 }
@@ -259,45 +265,37 @@ func (d *DelayQueue[T]) Dequeue(ctx context.Context) (T, error) {
 		return zeroValue, ctx.Err()
 	}
 
+	// 更新计数与启动/关闭 dequeueProxy 协程必须是原子的
 	d.dequeueMutex.Lock()
-	// 跟新计数与启动 dequeueProxy 协程必须是原子的
 	d.dequeueCallers++
-	// 第一个调用者负责启动 dequeueProxy 协程，在第一个调用者进入下方select语言前 dequeueProxy 必须启动
-	// todo: 防止 dequeueProxy 协程中途 panic 退出
-	//       可以使用 atomic.LoadInt64(&d.numOfDequeueProxyGo) == 0 作为启动 dequeueProxy 协程的条件
-	//       即在第一个检测到 dequeueProxy 协程没有启动的协程进入下方select前，需要将 dequeueProxy 协程启动起来
-	if d.dequeueCallers == 1 {
-		// 启动 dequeueProxy 协程后，阻塞等待
+	// 第一个检测到 dequeueProxy 协程没有启动的协程进入下方select前，需要将 dequeueProxy 协程启动起来
+	if atomic.LoadInt64(&d.numOfDequeueProxyGo) == 0 {
 		go d.dequeueProxy()
 		// dequeueProxy 协程启动后，唤醒当前协程
-		<-d.syncSignalFromDequeueProxy
+		<-d.continueSignalFromDequeueProxy
 	}
 	d.dequeueMutex.Unlock()
 
 	defer func() {
 		d.dequeueMutex.Lock()
-		// 更新计数与发送信号必须是原子的
 		d.dequeueCallers--
-		// 最后一个调用者通知 dequeueProxy 退出，在最后一个调用者退出前 dequeueProxy 必须退出
-		// todo: 防止 dequeueProxy 协程中途panic退出
-		//       可以使用 d.dequeueCallers == 0 && atomic.LoadInt64(&d.numOfDequeueProxyGo) == 1 作为通知 dequeueProxy 协程退出的条件
-		//       即最后一个检测到 dequeueProxy 协程存在的协程，在退出前需要确保 dequeueProxy 协程先于自己退出。
-		if d.dequeueCallers == 0 {
-			// 以非阻塞方式发送信号，通知poller协程走退出流程，当前协程阻塞等待
+		// 最后一个检测到 dequeueProxy 协程存在的协程，在退出前需要确保 dequeueProxy 协程先于自己退出。
+		if d.dequeueCallers == 0 && atomic.LoadInt64(&d.numOfDequeueProxyGo) == 1 {
+			// 以非阻塞方式发送信号，通知 dequeueProxy 协程走退出流程，当前协程阻塞等待
 			d.quitSignalForDequeueProxy <- struct{}{}
-			// poller协程退出前，通知当前协程退出
-			<-d.syncSignalFromDequeueProxy
+			// dequeueProxy 协程退出前，通知当前协程退出
+			<-d.continueSignalFromDequeueProxy
 		}
 		d.dequeueMutex.Unlock()
 	}()
 
-	log.Println("Dequeue, Waiting for element....")
+	// log.Println("Dequeue, Waiting for element....")
 
 	select {
 	case <-ctx.Done():
 		return zeroValue, ctx.Err()
 	case elem := <-d.expiredElements:
-		log.Println("Dequeue ...", elem)
+		// log.Println("Dequeue ...", elem)
 		return elem, nil
 	}
 }
@@ -305,33 +303,33 @@ func (d *DelayQueue[T]) Dequeue(ctx context.Context) (T, error) {
 func (d *DelayQueue[T]) dequeueProxy() {
 
 	defer func() {
+		// 吞掉panic
+		_ = recover()
+		// 必须先更新计数，再发送信号
 		atomic.CompareAndSwapInt64(&d.numOfDequeueProxyGo, 1, 0)
-		// todo: recover防止未知panic
-		// 发送退出信号，信号一定要在计数更新后发送
-		d.syncSignalFromDequeueProxy <- struct{}{}
-		log.Println("dequeueProxy stop....")
+		d.continueSignalFromDequeueProxy <- struct{}{}
+		// log.Println("dequeueProxy stop....")
 	}()
 
+	// 必须先更新计数，再发送信号
 	atomic.CompareAndSwapInt64(&d.numOfDequeueProxyGo, 0, 1)
-	log.Println("dequeueProxy start....")
-	// 发送启动信号，信号一个要在计数更新后发送
-	d.syncSignalFromDequeueProxy <- struct{}{}
+	d.continueSignalFromDequeueProxy <- struct{}{}
+	// log.Println("dequeueProxy start....")
 
 	defaultBlockingDuration := time.Hour
 	ticker := time.NewTicker(defaultBlockingDuration)
-
 	var remainingBlockingDuration time.Duration
 
 	for {
-		log.Println("dequeueProxy, peek before....")
+		// log.Println("dequeueProxy, peek before....")
 		d.mutex.RLock()
 		head, err := d.q.Peek()
 		d.mutex.RUnlock()
-		log.Println("dequeueProxy, peek after....")
+		// log.Println("dequeueProxy, peek after....")
 
 		// 队列为空
 		if err != nil {
-			log.Println("dequeueProxy, blocking before, queue empty....")
+			// log.Println("dequeueProxy, blocking before, queue empty....")
 			ticker.Reset(defaultBlockingDuration)
 			goto blocking
 		}
@@ -339,33 +337,33 @@ func (d *DelayQueue[T]) dequeueProxy() {
 		remainingBlockingDuration = time.Duration(head.Deadline().Unix() - time.Now().Unix())
 		if remainingBlockingDuration > 0 {
 			// 数据未过期
-			log.Println("dequeueProxy, blocking before, waiting duration ....", head, remainingBlockingDuration, time.Now())
+			// log.Println("dequeueProxy, blocking before, waiting duration ....", head, remainingBlockingDuration, time.Now())
 			ticker.Reset(remainingBlockingDuration)
 			goto blocking
 		} else {
 			// 数据已过期
-			log.Println("dequeueProxy, send before....")
+			// log.Println("dequeueProxy, send before....")
 			d.dequeueAndSendExpiredElement()
-			log.Println("dequeueProxy, send after....")
+			// log.Println("dequeueProxy, send after....")
 			// 重新获取队头
 			continue
 		}
 
 	blocking:
-		log.Println("dequeueProxy, blocking....")
+		// log.Println("dequeueProxy, blocking....")
 		select {
 		case <-d.quitSignalForDequeueProxy:
 			return
 		case <-ticker.C:
-			// 因为只有poller协程调用d.q.Dequeue()
+			// 因为只有 dequeueProxy 协程调用d.q.Dequeue()
 			// 阻塞醒来后是可以立即调用d.q.Dequeue()，即便与b.q.Enqueue()并发也是正确的。
-			// 不存在原队头被其他协程并发调用d.q.Dequeue()出队的情况(不允许出现多poller实例的情况）
+			// 不存在原队头被其他协程并发调用d.q.Dequeue()出队的情况(前提单 dequeueProxy 实例）
 			// 为了便于理解程序，将下方调用代码注释，不注释下方调用的逻辑分析见方法内部注释
 			// d.dequeueAndSendExpiredElement()
-			log.Println("dequeueProxy, unblocked by Ticker.....")
+			// log.Println("dequeueProxy, unblocked by Ticker.....")
 		case <-d.wakeupSignalForDequeueProxy:
 			// 队头更新，再次检查
-			log.Println("dequeueProxy, unblocked by Signal.....")
+			// log.Println("dequeueProxy, unblocked by Signal.....")
 		}
 	}
 }
@@ -400,14 +398,14 @@ func (d *DelayQueue[T]) dequeueAndSendExpiredElement() {
 	// 否则唯一的Dequeue调用者协程因ctx超时走退出流程时，
 	// Dequeue 调用者协程等待在 d.quitSignalForDequeueProxy 上而 dequeueProxy 协程等待在 d.expiredElements <- expired 上从而形成两者相互等待
 	d.expiredElements <- expired
-	log.Println("dequeueProxy, element dequeued .... ", expired, d.q.Len())
+	// log.Println("dequeueProxy, element dequeued .... ", expired, d.q.Len())
 
 	// 之前容量为满，enqueueProxy 可能被阻塞
-	enqueueProxyMayBeBlocked := d.q.Len()+len(d.expiredElements) == d.capacity
-	thereIsNoUnreceivedWakeupSignal := len(d.wakeupSignalForEnqueueProxy) == 0
-	if enqueueProxyMayBeBlocked && thereIsNoUnreceivedWakeupSignal {
-		d.wakeupSignalForEnqueueProxy <- struct{}{}
-	}
+	// enqueueProxyMayBeBlocked := d.q.Len()+len(d.expiredElements) == d.capacity
+	// thereIsNoUnreceivedWakeupSignal := len(d.wakeupSignalForEnqueueProxy) == 0
+	// if enqueueProxyMayBeBlocked && thereIsNoUnreceivedWakeupSignal {
+	// 	d.wakeupSignalForEnqueueProxy <- struct{}{}
+	// }
 }
 
 func (d *DelayQueue[T]) Len() int {

--- a/queue/delay_queue_test.go
+++ b/queue/delay_queue_test.go
@@ -1,152 +1,586 @@
-package queue_test
+package queue
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/gotomicro/ekit/queue"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/errgroup"
 )
 
-func TestDelayQueue_Enqueue(t *testing.T) {
+func TestDelayQueue_New(t *testing.T) {
+	t.Parallel()
 
-	q := newDelayQueue[*Int]()
+	_, err := testNewDelayQueue[*Int](0)
+	assert.ErrorIs(t, err, errInvalidArgument)
+
+	_, err = testNewDelayQueue[*Int](-1)
+	assert.ErrorIs(t, err, errInvalidArgument)
+
+	_, err = NewDelayQueue[*Int](1, nil)
+	assert.ErrorIs(t, err, errInvalidArgument)
+
+	q, err := testNewDelayQueue[*Int](1)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, q.Len())
+}
+
+func TestDelayQueue_Enqueue(t *testing.T) {
+	t.Parallel()
 
 	t.Run("超时控制", func(t *testing.T) {
+		t.Parallel()
 
 		t.Run("直接超时", func(t *testing.T) {
+			t.Parallel()
 
-			cancelCtx, cancelFunc := context.WithCancel(context.Background())
-			cancelFunc()
-			assert.ErrorIs(t, q.Enqueue(cancelCtx, newInt(1, time.Second)), context.Canceled)
-
-			timeoutCtx, timeoutCancelFunc := context.WithTimeout(context.Background(), time.Nanosecond)
-			assert.Equal(t, q.Enqueue(timeoutCtx, newInt(2, time.Second)), context.DeadlineExceeded)
-			timeoutCancelFunc()
-
-			deadlineCtx, deadlineCancelFunc := context.WithDeadline(context.Background(), time.Now().Add(1))
-			assert.Equal(t, q.Enqueue(deadlineCtx, newInt(3, time.Second)), context.DeadlineExceeded)
-			deadlineCancelFunc()
-		})
-
-		t.Run("排队超时", func(t *testing.T) {
-
-			var eg errgroup.Group
-
-			n := 50
-			waitChan := make(chan struct{})
-			for i := 0; i < n; i++ {
-				i := i
-				eg.Go(func() error {
-					<-waitChan
-					timeoutCtx, cancelFunc := context.WithTimeout(context.Background(), 100*time.Nanosecond)
-					defer cancelFunc()
-					return q.Enqueue(timeoutCtx, newInt(i, time.Millisecond))
-				})
-			}
-
-			// waitChan <- struct{}{}
-			close(waitChan)
-			assert.Equal(t, context.DeadlineExceeded, eg.Wait())
-
+			testPassCanceledCtxToEnqueueOrDequeueOperation(t, func(q *DelayQueue[*Int], i int, ctx context.Context) error {
+				return q.Enqueue(ctx, newInt(i, time.Second))
+			})
 		})
 
 		t.Run("等待超时", func(t *testing.T) {
+			t.Parallel()
+
+			testContextTimeoutInEnqueueOrDequeueOperation(t, func(q *DelayQueue[*Int], i int, ctx context.Context) error {
+				return q.Enqueue(ctx, newInt(i, 100*time.Millisecond))
+			})
 
 		})
 	})
 
-	t.Run("单协程", func(t *testing.T) {
+	t.Run("Enqueue与Dequeue串行", func(t *testing.T) {
+		t.Parallel()
 
-		t.Run("出队", func(t *testing.T) {
+		t.Run("无Dequeue，Enqueue之间串行", func(t *testing.T) {
+			t.Parallel()
 
-			t.Run("直接超时", func(t *testing.T) {
+			t.Run("队列未满", func(t *testing.T) {
+				t.Parallel()
 
+				capacity, numOfEnqueue, expectedError := 3, 2, (error)(nil)
+				testCallEnqueueSequentially(t, capacity, numOfEnqueue, expectedError, func(t *testing.T, q *DelayQueue[*Int], capacity int, numOfEnqueue int) {
+					assert.Equal(t, numOfEnqueue, q.Len())
+				})
 			})
 
-			t.Run("排队超时", func(t *testing.T) {
+			t.Run("队列刚满", func(t *testing.T) {
+				t.Parallel()
 
+				capacity, numOfEnqueue, expectedError := 3, 3, (error)(nil)
+				testCallEnqueueSequentially(t, capacity, numOfEnqueue, expectedError, func(t *testing.T, q *DelayQueue[*Int], capacity int, numOfEnqueue int) {
+					assert.Equal(t, numOfEnqueue, q.Len())
+				})
 			})
 
-			t.Run("等待超时", func(t *testing.T) {
+			t.Run("队列超满", func(t *testing.T) {
+				t.Parallel()
 
+				capacity, numOfEnqueue, expectedError := 3, 4, errOutOfCapacity
+				testCallEnqueueSequentially(t, capacity, numOfEnqueue, expectedError, func(t *testing.T, q *DelayQueue[*Int], capacity int, numOfEnqueue int) {
+					assert.Equal(t, capacity, q.Len())
+				})
 			})
 		})
 
-		t.Run("延迟", func(t *testing.T) {
+		t.Run("无Dequeue, Enqueue之间并发", func(t *testing.T) {
+			t.Parallel()
 
+			t.Run("队列未满", func(t *testing.T) {
+				t.Parallel()
+
+				capacity, numOfEnqueueGo, expectedErr := 3, 2, (error)(nil)
+				testCallEnqueueConcurrently(t, capacity, numOfEnqueueGo, expectedErr, func(t *testing.T, q *DelayQueue[*Int], capacity int, numOfEnqueueGo int) {
+					assert.Equal(t, numOfEnqueueGo, q.Len())
+				})
+			})
+
+			t.Run("队列刚满", func(t *testing.T) {
+				t.Parallel()
+
+				capacity, numOfEnqueueGo, expectedErr := 3, 3, (error)(nil)
+				testCallEnqueueConcurrently(t, capacity, numOfEnqueueGo, expectedErr, func(t *testing.T, q *DelayQueue[*Int], capacity int, numOfEnqueueGo int) {
+					assert.Equal(t, numOfEnqueueGo, q.Len())
+				})
+			})
+
+			t.Run("队列超满", func(t *testing.T) {
+				t.Parallel()
+
+				capacity, numOfEnqueueGo, expectedErr := 3, 5, errOutOfCapacity
+				testCallEnqueueConcurrently(t, capacity, numOfEnqueueGo, expectedErr, func(t *testing.T, q *DelayQueue[*Int], capacity int, numOfEnqueueGo int) {
+					assert.Equal(t, capacity, q.Len())
+				})
+			})
 		})
+
+		// 有Dequeue，Enqueue之间串行，Dequeue之间串行/并发（无所谓）详见下方 TestDelayQueue_Dequeue/Enqueue与Dequeue串行
+
+		// 有Dequeue，Enqueue之间并发，Dequeue之间串行/并行（无所谓）详见下方 TestDelayQueue_Dequeue/Enqueue与Dequeue串行
 
 	})
 
+	// Enqueue与Dequeue之间并发，详见下发 TestDelayQueue_Enqueue_Dequeue
 }
 
-// Dequeue
-// Case 1:
-//  queue = {100},
-//   A. g1 Dequeue，阻塞（在锁中，去阻塞的路上，阻塞中）
-//      1）超时退出
-//      2）获取数据成功；
-//      3）永久阻塞 —— 不需要处理，使用者不设置超时导致
-//   B. g1，g2 ...gX Dequeue，阻塞（在锁中，去阻塞的路上，阻塞中）
-//      1）全部超时退出
-//      2）部分获取数据，部分超时退出
-//      3）部分获取数据成功，其他永久阻塞 —— 不需要处理，使用者不设置超时导致
-//   C. g1 Dequeue, 阻塞中，
-//      1） g2 Enqueue(120), queue = {100, 120}，g1 不受影响阻塞不中断
-//      2） g2 Enqueue(1), queue = {1, 100}, g1被唤醒，重新获取队头，再次阻塞指定时间；
-//          这里"1"的定义应该是从Enqueue->Dequeue出元素的最大时间，与之前阻塞多久没关系。
-//   D. g1，g2，g3 Dequeue，阻塞中
-//      1）g4 Enqueue(120),queue = {100, 120}, g1，g2，g3继续阻塞不受影响（重复多次）；
-//      2) g4 Enqueue(10), queue = {10, 120},g1/g2/g3被唤醒，再次阻塞指定时间（重复多次）
-//         a. 如果唤醒一个，因为ctx检查点的存在，可能导致刚被唤醒的协程直接退出，其他两个协程仍然在阻塞中
-//         b. 如果唤醒全部，同上，仍有可能全部协程因ctx检查点退出，也可能导致大量协程（1k/1w）被唤醒但做的是无用功。
-//                唤醒全部，只能增加调度开销，但更新了所有协程的等待时间，增加了获取最新时机
-//                queue = {100, 120}, enqueue（1），唤醒全部协程，恰巧再次select的ticker和ctx.Done时因超时退出，
-//                这种情况，与queue={1}，一直没人调Dequeue情况一致。
-//         c. 只要进入Dequeue就表明你有获取数据的意愿，至少上你尝试获取数据一次，去掉for循环中检查ctx检查点，
-//            只让其在和ticker/信号队列的select中退出。问题就是超时时间不准确稍稍之后，或者刚拿到最新队头信息，超时了。
-//         d. 不公平问题，因调度的随机性（chan先检查对面有没有人再放入缓冲去正所谓来的早，不如来的巧)，
-//            先Dequeue的协程不一定能获取数据，可能稍稍滞后的超时退出，也可能永久阻塞（调用者的使用问题，提供超时机制你不用，不能怪设计者）
-// Case 2:
-//  queue = {10, 5},
-//   A. 与Case1.A相同
-//   B. g1, g2, ...gX Dequeue，阻塞（在锁中，去阻塞的路上，阻塞中）
-//      1）都超时退出
-//      2）2个获取数据成功，其他超时退出
-//      3）2个获取数据成功，其他永久阻塞 —— 不需要处理，使用者不设置超时导致
-// Case 3:
-//  queue = {10, 5, 2}
-//   A. 退化为Case1.A 或者 Case2.A
-//   B. 退化为Case1.B 或者 Case2.B
-// Case 4:
-//  queue = {},
-//   A. g1 Dequeue, 阻塞（在锁中，去阻塞的路上，阻塞中）；g2，Enqueue(X)成功，通知g1，g1获取数据X成功！
-//   B. g1,g2 Dequeue, 阻塞（在锁中，去阻塞的路上，阻塞中）；g3，Enqueue(Y)成功，通知g1或g2，
-//      1）都因超时而退出
-//      2）一个获取数据Y成功，另一个超时退出
-//      3) 一个获取数据Y成功，另一个阻塞直到下一次Enqueue(Z),退化为Case4.A情况
-//         要考虑队列内部状态，比如通知信号队列中是空/满等,最好使用使用固定长度的队列，这样信号队列的容量可以为capacity
-//  C. g1, g2 Dequeue，阻塞（在锁中，去阻塞的路上，阻塞中）；g3 Dequeue 阻塞； g4，Enqueue(10, 12, 15)成功发送"1次"通知给g1/g2/g3，
-//     0) bug:有一个协程被唤醒，去Peek，在select的ticker和ctx.Done()阻塞时，可能因ctx.Done()退出，而导致无法将队头元素按时取出
-//        解决方法：采取异步通知go func(){}，唤醒全部等待在Dequeue上的协程数（考虑信号队列的capacity来确定发送信号的数量）。
-//     1) 全都超时退出
-//        拿到信号了，但因再次阻塞时超时而退出，正如次才要唤醒全部等待者，一来，更新所有等待时间；二来，增大获取数据的几率；
-//     2) 全部获取数据成功
-//     3）部分获取数据成功，部分阻塞 queue = {15} 因下一个Enqueue(8)的通知，queue = {8, 15}
-//        退化称为Case2.B —— 可能触发Bug，只唤醒一个，丢失信号，需要唤醒多个或这全部，以保证协程更新阻塞时间，阻塞时间为0时即可拿到数据出队；
-//   C.  g1, g2 Dequeue，阻塞（在锁中，去阻塞的路上，阻塞中）；g3 Dequeue ，阻塞 g4，Enqueue(10, 2)成功，发送"两次"（多次）通知给g1/g2/g3，
-//       1) 全部因超时而退出
-//        拿到信号了，但因再次阻塞时超时而退出，正如次才要唤醒全部等待者，一来，更新所有等待时间；二来，增大获取数据的几率；
-//       2) 全部成功获取数据
-//       3）部分获取数据成功，部分超时退出
-//       4）部分成功获取数据，部分阻塞
-//          a. 不再有Enqueue并发调用，退化为Case2
-//          b. 还是会有Enqueue并发调用，退化为Case1.D
+func TestDelayQueue_Dequeue(t *testing.T) {
 
-// 本质上来说，
+	t.Run("超时控制", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("直接超时", func(t *testing.T) {
+			t.Parallel()
+
+			testPassCanceledCtxToEnqueueOrDequeueOperation(t, func(q *DelayQueue[*Int], i int, ctx context.Context) error {
+				_, err := q.Dequeue(ctx)
+				return err
+			})
+		})
+
+		t.Run("等待超时", func(t *testing.T) {
+			t.Parallel()
+
+			testContextTimeoutInEnqueueOrDequeueOperation(t, func(q *DelayQueue[*Int], i int, ctx context.Context) error {
+				_, err := q.Dequeue(ctx)
+				return err
+			})
+		})
+	})
+
+	t.Run("Enqueue与Dequeue串行", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("无Enqueue，Dequeue之间串行", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("队列为空，Dequeue协程超时退出", func(t *testing.T) {
+				t.Parallel()
+
+				capacity, numOfDequeue := 1, 3
+				q, err := testNewDelayQueue[*Int](capacity)
+				assert.NoError(t, err)
+				assert.Equal(t, 0, q.Len())
+
+				for i := 0; i < numOfDequeue; i++ {
+					func() {
+						ctx, cancelFunc := context.WithTimeout(context.Background(), time.Millisecond)
+						defer cancelFunc()
+						_, err := q.Dequeue(ctx)
+						assert.Equal(t, context.DeadlineExceeded, err)
+					}()
+				}
+
+				assert.Equal(t, 0, q.Len())
+			})
+		})
+
+		t.Run("无Enqueue，Dequeue之间并发", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("队列为空，并发Dequeue协程超时退出", func(t *testing.T) {
+				t.Parallel()
+
+				capacity, numOfDequeueGo := 1, 3
+				q, err := testNewDelayQueue[*Int](capacity)
+				assert.NoError(t, err)
+				assert.Equal(t, 0, q.Len())
+
+				errChan := make(chan error, numOfDequeueGo)
+				for i := 0; i < numOfDequeueGo; i++ {
+					go func() {
+						ctx, cancelFunc := context.WithTimeout(context.Background(), time.Millisecond)
+						defer cancelFunc()
+						_, err := q.Dequeue(ctx)
+						errChan <- err
+					}()
+				}
+
+				for i := 0; i < numOfDequeueGo; i++ {
+					assert.Equal(t, context.DeadlineExceeded, <-errChan)
+				}
+
+				assert.Equal(t, 0, q.Len())
+			})
+
+		})
+
+		t.Run("有Enqueue, Enqueue之间并发，Dequeue之间串行", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("队列从满到空", func(t *testing.T) {
+				t.Parallel()
+
+				n := 3
+				q, err := testNewDelayQueue[*Int](n)
+				assert.NoError(t, err)
+
+				// 并发Enqueue
+				var eg errgroup.Group
+				for i := 0; i < n; i++ {
+					i := i
+					eg.Go(func() error {
+						return q.Enqueue(context.Background(), newInt(i, time.Millisecond))
+					})
+				}
+
+				assert.NoError(t, eg.Wait())
+				// 队列已满
+				assert.Equal(t, n, q.Len())
+
+				// 与上方Enqueue串行，与后续Dequeue也串行
+				for i := 0; i < n; i++ {
+					d, err := q.Dequeue(context.Background())
+					assert.NoError(t, err)
+					assert.True(t, d.isExpired(time.Now()))
+				}
+
+				assert.Equal(t, 0, q.Len())
+			})
+		})
+
+		t.Run("有Enqueue，Enqueue之间串行，Dequeue之间并发", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("队列从满到空", func(t *testing.T) {
+				t.Parallel()
+
+				n := 3
+				q, err := testNewDelayQueue[*Int](n)
+				assert.NoError(t, err)
+
+				// 串行Enqueue
+				for i := 0; i < n; i++ {
+					duration := 10*time.Millisecond + time.Duration(i)*10*time.Millisecond
+					assert.NoError(t, q.Enqueue(context.Background(), newInt(i, duration)))
+				}
+
+				// 队列已满
+				assert.Equal(t, n, q.Len())
+
+				// 未调用Dequeue方法， dequeueProxy 协程一定不存在
+				assert.Equal(t, int64(0), atomic.LoadInt64(&q.numOfDequeueProxyGo))
+
+				var eg errgroup.Group
+				expiredElements := make(chan *Int, n)
+				for i := 0; i < n; i++ {
+					eg.Go(func() error {
+						e, err := q.Dequeue(context.Background())
+						expiredElements <- e
+						return err
+					})
+				}
+
+				assert.NoError(t, eg.Wait())
+				assert.Equal(t, 0, q.Len())
+
+				// 最后一个Dequeue返回后，dequeueProxy 协程必须退出
+				assert.Equal(t, int64(0), atomic.LoadInt64(&q.numOfDequeueProxyGo))
+
+				now := time.Now()
+
+				// 取出的元素必须过期，间接验证 dequeueProxy 协程被创建
+				for i := 0; i < n; i++ {
+					elem := <-expiredElements
+					assert.True(t, elem.isExpired(now))
+				}
+			})
+		})
+
+	})
+
+	// Enqueue与Dequeue之间并发，详见下发 TestDelayQueue_Enqueue_Dequeue
+}
+
+func TestDelayQueue_Enqueue_Dequeue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Enqueue与Dequeue并发，Enqueue与Dequeue上均有并发", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("1:1，队列初始为空，先1个Dequeue阻塞后并发1个Enqueue，队列为空", func(t *testing.T) {
+			t.Parallel()
+
+			q, err := testNewDelayQueue[*Int](1)
+			assert.NoError(t, err)
+
+			assert.Equal(t, 0, q.Len())
+
+			syncChan := make(chan struct{})
+			resultChan := make(chan *DequeueResult[*Int], 1)
+			go func() {
+				syncChan <- struct{}{}
+				data, err := q.Dequeue(context.Background())
+				resultChan <- newDequeueResult(data, err)
+			}()
+
+			<-syncChan
+			expected := newInt(1, time.Millisecond)
+			assert.NoError(t, q.Enqueue(context.Background(), expected))
+
+			result := <-resultChan
+			assert.Equal(t, expected, result.data)
+			assert.NoError(t, result.err)
+		})
+
+		t.Run("1:N, 先1个Dequeue阻塞后并发N个Enqueue，队列中有数据", func(t *testing.T) {
+			t.Parallel()
+
+			n := 4
+			q, err := testNewDelayQueue[*Int](n)
+			assert.NoError(t, err)
+
+			assert.Equal(t, 0, q.Len())
+
+			m := 1
+			dequeueResultChan := make(chan *DequeueResult[*Int], m)
+			go func() {
+				data, err := q.Dequeue(context.Background())
+				dequeueResultChan <- newDequeueResult(data, err)
+			}()
+
+			enqueueErrChan := make(chan error, n)
+			for i := 0; i < n; i++ {
+				i := i
+				go func() {
+					enqueueErrChan <- q.Enqueue(context.Background(), newInt(i, time.Millisecond))
+					t.Log("i = ", i, "len = ", q.Len())
+
+				}()
+			}
+
+			for i := 0; i < n; i++ {
+				assert.NoError(t, <-enqueueErrChan)
+			}
+
+			result := <-dequeueResultChan
+			assert.True(t, result.data.isExpired(time.Now()))
+			assert.NoError(t, result.err)
+
+			assert.Equal(t, n-m, q.Len())
+		})
+
+		t.Run("新元素入队，队头无影响，仍返回原队头", func(t *testing.T) {
+			t.Parallel()
+
+			ascDeadline := func(i int) time.Duration {
+				return 1000*time.Millisecond + time.Duration(i)*200*time.Millisecond
+			}
+
+			t.Run("期间，队列未曾满", func(t *testing.T) {
+				t.Parallel()
+				capacity, numOfEnqueueGo, numOfDequeueGo := 5, 4, 4
+				testCallEnqueueAndDequeueConcurrently(t, capacity, numOfEnqueueGo, numOfDequeueGo, ascDeadline, nil, nil)
+			})
+
+			t.Run("期间，队列恰好满", func(t *testing.T) {
+				t.Parallel()
+				capacity, numOfEnqueueGo, numOfDequeueGo := 5, 5, 5
+				testCallEnqueueAndDequeueConcurrently(t, capacity, numOfEnqueueGo, numOfDequeueGo, ascDeadline, nil, nil)
+			})
+
+			t.Run("期间，队列曾塞满", func(t *testing.T) {
+				t.Parallel()
+				capacity, numOfEnqueueGo, numOfDequeueGo := 5, 8, 5
+				testCallEnqueueAndDequeueConcurrently(t, capacity, numOfEnqueueGo, numOfDequeueGo, ascDeadline, errOutOfCapacity, nil)
+			})
+		})
+
+		t.Run("新元素入队，队头改变，返回新队头", func(t *testing.T) {
+			t.Parallel()
+
+			descDeadline := func(i int) time.Duration {
+				return 2000*time.Millisecond - time.Duration(i)*200*time.Millisecond
+			}
+
+			t.Run("期间，队列未曾满", func(t *testing.T) {
+				t.Parallel()
+				capacity, numOfEnqueueGo, numOfDequeueGo := 5, 4, 4
+				testCallEnqueueAndDequeueConcurrently(t, capacity, numOfEnqueueGo, numOfDequeueGo, descDeadline, nil, nil)
+			})
+
+			t.Run("期间，队列恰好满", func(t *testing.T) {
+				t.Parallel()
+				capacity, numOfEnqueueGo, numOfDequeueGo := 5, 5, 5
+				testCallEnqueueAndDequeueConcurrently(t, capacity, numOfEnqueueGo, numOfDequeueGo, descDeadline, nil, nil)
+			})
+
+			t.Run("期间，队列曾塞满", func(t *testing.T) {
+				t.Parallel()
+				capacity, numOfEnqueueGo, numOfDequeueGo := 5, 8, 5
+				testCallEnqueueAndDequeueConcurrently(t, capacity, numOfEnqueueGo, numOfDequeueGo, descDeadline, errOutOfCapacity, nil)
+			})
+		})
+
+	})
+
+	t.Run("N:1", func(t *testing.T) {
+		t.Parallel()
+	})
+
+	t.Run("N:N", func(t *testing.T) {
+		t.Parallel()
+	})
+
+	t.Run("N:M", func(t *testing.T) {
+		t.Parallel()
+	})
+
+	t.Run("M:N", func(t *testing.T) {
+		t.Parallel()
+	})
+}
+
+func testCallEnqueueSequentially(t *testing.T, capacity int, numOfEnqueue int, expectedError error, lenAssertFunc func(t *testing.T, q *DelayQueue[*Int], capacity int, numOfEnqueue int)) {
+
+	q, err := testNewDelayQueue[*Int](capacity)
+	assert.NoError(t, err)
+
+	for i := 0; i < numOfEnqueue-1; i++ {
+		assert.NoError(t, q.Enqueue(context.Background(), newInt(i, time.Microsecond)))
+		// 顺序调用，Enqueue调用者即是第一个（启动 enqueueProxy）又是最后一个（关闭 enqueueProxy）
+		assert.Equal(t, int64(0), atomic.LoadInt64(&q.numOfEnqueueProxyGo))
+	}
+
+	// 超时控制
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancelFunc()
+	assert.Equal(t, expectedError, q.Enqueue(ctx, newInt(numOfEnqueue, time.Microsecond)))
+
+	lenAssertFunc(t, q, capacity, numOfEnqueue)
+}
+
+func testCallEnqueueConcurrently(t *testing.T, capacity int, numOfEnqueueGo int, expectedErr error, lenAssertFunc func(t *testing.T, q *DelayQueue[*Int], capacity int, numOfEnqueueGo int)) {
+
+	q, err := testNewDelayQueue[*Int](capacity)
+	assert.NoError(t, err)
+
+	// Enqueue之前，enqueueProxy 协程必须未启动
+	assert.Equal(t, int64(0), atomic.LoadInt64(&q.numOfEnqueueProxyGo))
+
+	var eg errgroup.Group
+	for i := 0; i < numOfEnqueueGo; i++ {
+		i := i
+		eg.Go(func() error {
+			err := q.Enqueue(context.Background(), newInt(i, time.Microsecond))
+			// syncChan <- struct{}{}
+			return err
+		})
+	}
+
+	assert.Equal(t, expectedErr, eg.Wait())
+
+	// 最后一个Enqueue方法返回后，enqueueProxy 协程必须退出
+	assert.Equal(t, int64(0), atomic.LoadInt64(&q.numOfEnqueueProxyGo))
+
+	// 通过队列的长度来间接验证 enqueueProxy 协程正常工作
+	lenAssertFunc(t, q, capacity, numOfEnqueueGo)
+}
+
+func testCallEnqueueAndDequeueConcurrently(t *testing.T, capacity int, numOfEnqueueGo int, numOfDequeueGo int, deadlineFunc func(i int) time.Duration, enqueueError error, dequeueError error) {
+
+	q, err := testNewDelayQueue[*Int](capacity)
+	assert.NoError(t, err)
+
+	// 未调用Dequeue方法， dequeueProxy 协程一定不存在
+	assert.Equal(t, int64(0), atomic.LoadInt64(&q.numOfDequeueProxyGo))
+
+	var dequeueErrGroup errgroup.Group
+	expiredElements := make(chan *Int, numOfDequeueGo)
+	syncChan := make(chan struct{}, numOfDequeueGo)
+
+	for i := 0; i < numOfDequeueGo; i++ {
+		dequeueErrGroup.Go(func() error {
+			e, err := q.Dequeue(context.Background())
+			syncChan <- struct{}{}
+			expiredElements <- e
+			return err
+		})
+	}
+
+	// 并发入队
+	var enqueueErrGroup errgroup.Group
+	for i := 0; i < numOfEnqueueGo; i++ {
+		i := i
+		enqueueErrGroup.Go(func() error {
+			// duration := 1000*time.Millisecond + time.Duration(i)*200*time.Millisecond
+			return q.Enqueue(context.Background(), newInt(i, deadlineFunc(i)))
+		})
+	}
+
+	<-syncChan
+
+	// 第一个Dequeue返回后，dequeueProxy 协程必须启动
+	assert.Equal(t, int64(1), atomic.LoadInt64(&q.numOfDequeueProxyGo))
+
+	assert.Equal(t, dequeueError, dequeueErrGroup.Wait())
+	now := time.Now()
+	assert.Equal(t, enqueueError, enqueueErrGroup.Wait())
+
+	// 最后一个Dequeue返回后，dequeueProxy 协程必须退出
+	assert.Equal(t, int64(0), atomic.LoadInt64(&q.numOfDequeueProxyGo))
+
+	// 取出的元素相同并且过期
+	for i := 0; i < numOfDequeueGo; i++ {
+		elem := <-expiredElements
+		assert.True(t, elem.isExpired(now))
+	}
+}
+
+func testPassCanceledCtxToEnqueueOrDequeueOperation(t *testing.T, op func(q *DelayQueue[*Int], i int, ctx context.Context) error) {
+	q, err := testNewDelayQueue[*Int](1)
+	assert.NoError(t, err)
+
+	createContextFns := []func() (context.Context, context.CancelFunc){
+		func() (context.Context, context.CancelFunc) {
+			return context.WithCancel(context.Background())
+		},
+		func() (context.Context, context.CancelFunc) {
+			return context.WithTimeout(context.Background(), time.Nanosecond)
+		},
+		func() (context.Context, context.CancelFunc) {
+			return context.WithDeadline(context.Background(), time.Now().Add(1))
+		},
+	}
+
+	errChan := make(chan error, len(createContextFns))
+	for i, fn := range createContextFns {
+		i, fn := i, fn
+		go func() {
+			ctx, cancelFunc := fn()
+			cancelFunc()
+			errChan <- op(q, i, ctx)
+		}()
+	}
+
+	for i := 0; i < len(createContextFns); i++ {
+		assert.Error(t, <-errChan)
+	}
+}
+
+func testContextTimeoutInEnqueueOrDequeueOperation(t *testing.T, op func(q *DelayQueue[*Int], i int, ctx context.Context) error) {
+	var eg errgroup.Group
+
+	q, err := testNewDelayQueue[*Int](10)
+	assert.NoError(t, err)
+
+	n := 10
+	waitChan := make(chan int, n)
+	for i := 0; i < n; i++ {
+		i := i
+		eg.Go(func() error {
+			waitChan <- i
+			timeoutCtx, cancelFunc := context.WithTimeout(context.Background(), 1*time.Microsecond)
+			defer cancelFunc()
+			return op(q, i, timeoutCtx)
+		})
+	}
+	for i := 0; i < n; i++ {
+		<-waitChan
+	}
+	assert.Equal(t, context.DeadlineExceeded, eg.Wait())
+}
 
 type Int struct {
 	id       int
@@ -161,8 +595,12 @@ func (i *Int) Delay() time.Duration {
 	return i.deadline
 }
 
-func newDelayQueue[T queue.Delayable[T]]() *queue.DelayQueue[T] {
-	return queue.NewDelayQueue[T](func(t1 T, t2 T) int {
+func (i *Int) isExpired(now time.Time) bool {
+	return time.Duration(now.Unix())-i.deadline >= 0
+}
+
+func testNewDelayQueue[T Delayable[T]](capacity int) (*DelayQueue[T], error) {
+	return NewDelayQueue[T](capacity, func(t1 T, t2 T) int {
 		if int64(t1.Delay()) < int64(t2.Delay()) {
 			return -1
 		} else if int64(t1.Delay()) == int64(t2.Delay()) {
@@ -173,9 +611,11 @@ func newDelayQueue[T queue.Delayable[T]]() *queue.DelayQueue[T] {
 	})
 }
 
-func TestUnixTime(t *testing.T) {
-	delay := 10 * time.Second
-	now := time.Now()
-	deadline := now.Add(delay)
-	assert.Equal(t, 10*time.Second, time.Duration(deadline.UnixNano()-now.UnixNano()))
+type DequeueResult[T Delayable[T]] struct {
+	data T
+	err  error
+}
+
+func newDequeueResult[T Delayable[T]](data T, err error) *DequeueResult[T] {
+	return &DequeueResult[T]{data: data, err: err}
 }

--- a/queue/delay_queue_test.go
+++ b/queue/delay_queue_test.go
@@ -1,0 +1,181 @@
+package queue_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gotomicro/ekit/queue"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestDelayQueue_Enqueue(t *testing.T) {
+
+	q := newDelayQueue[*Int]()
+
+	t.Run("超时控制", func(t *testing.T) {
+
+		t.Run("直接超时", func(t *testing.T) {
+
+			cancelCtx, cancelFunc := context.WithCancel(context.Background())
+			cancelFunc()
+			assert.ErrorIs(t, q.Enqueue(cancelCtx, newInt(1, time.Second)), context.Canceled)
+
+			timeoutCtx, timeoutCancelFunc := context.WithTimeout(context.Background(), time.Nanosecond)
+			assert.Equal(t, q.Enqueue(timeoutCtx, newInt(2, time.Second)), context.DeadlineExceeded)
+			timeoutCancelFunc()
+
+			deadlineCtx, deadlineCancelFunc := context.WithDeadline(context.Background(), time.Now().Add(1))
+			assert.Equal(t, q.Enqueue(deadlineCtx, newInt(3, time.Second)), context.DeadlineExceeded)
+			deadlineCancelFunc()
+		})
+
+		t.Run("排队超时", func(t *testing.T) {
+
+			var eg errgroup.Group
+
+			n := 50
+			waitChan := make(chan struct{})
+			for i := 0; i < n; i++ {
+				i := i
+				eg.Go(func() error {
+					<-waitChan
+					timeoutCtx, cancelFunc := context.WithTimeout(context.Background(), 100*time.Nanosecond)
+					defer cancelFunc()
+					return q.Enqueue(timeoutCtx, newInt(i, time.Millisecond))
+				})
+			}
+
+			// waitChan <- struct{}{}
+			close(waitChan)
+			assert.Equal(t, context.DeadlineExceeded, eg.Wait())
+
+		})
+
+		t.Run("等待超时", func(t *testing.T) {
+
+		})
+	})
+
+	t.Run("单协程", func(t *testing.T) {
+
+		t.Run("出队", func(t *testing.T) {
+
+			t.Run("直接超时", func(t *testing.T) {
+
+			})
+
+			t.Run("排队超时", func(t *testing.T) {
+
+			})
+
+			t.Run("等待超时", func(t *testing.T) {
+
+			})
+		})
+
+		t.Run("延迟", func(t *testing.T) {
+
+		})
+
+	})
+
+}
+
+// Dequeue
+// Case 1:
+//  queue = {100},
+//   A. g1 Dequeue，阻塞（在锁中，去阻塞的路上，阻塞中）
+//      1）超时退出
+//      2）获取数据成功；
+//      3）永久阻塞 —— 不需要处理，使用者不设置超时导致
+//   B. g1，g2 ...gX Dequeue，阻塞（在锁中，去阻塞的路上，阻塞中）
+//      1）全部超时退出
+//      2）部分获取数据，部分超时退出
+//      3）部分获取数据成功，其他永久阻塞 —— 不需要处理，使用者不设置超时导致
+//   C. g1 Dequeue, 阻塞中，
+//      1） g2 Enqueue(120), queue = {100, 120}，g1 不受影响阻塞不中断
+//      2） g2 Enqueue(1), queue = {1, 100}, g1被唤醒，重新获取队头，再次阻塞指定时间；
+//          这里"1"的定义应该是从Enqueue->Dequeue出元素的最大时间，与之前阻塞多久没关系。
+//   D. g1，g2，g3 Dequeue，阻塞中
+//      1）g4 Enqueue(120),queue = {100, 120}, g1，g2，g3继续阻塞不受影响（重复多次）；
+//      2) g4 Enqueue(10), queue = {10, 120},g1/g2/g3被唤醒，再次阻塞指定时间（重复多次）
+//         a. 如果唤醒一个，因为ctx检查点的存在，可能导致刚被唤醒的协程直接退出，其他两个协程仍然在阻塞中
+//         b. 如果唤醒全部，同上，仍有可能全部协程因ctx检查点退出，也可能导致大量协程（1k/1w）被唤醒但做的是无用功。
+//                唤醒全部，只能增加调度开销，但更新了所有协程的等待时间，增加了获取最新时机
+//                queue = {100, 120}, enqueue（1），唤醒全部协程，恰巧再次select的ticker和ctx.Done时因超时退出，
+//                这种情况，与queue={1}，一直没人调Dequeue情况一致。
+//         c. 只要进入Dequeue就表明你有获取数据的意愿，至少上你尝试获取数据一次，去掉for循环中检查ctx检查点，
+//            只让其在和ticker/信号队列的select中退出。问题就是超时时间不准确稍稍之后，或者刚拿到最新队头信息，超时了。
+//         d. 不公平问题，因调度的随机性（chan先检查对面有没有人再放入缓冲去正所谓来的早，不如来的巧)，
+//            先Dequeue的协程不一定能获取数据，可能稍稍滞后的超时退出，也可能永久阻塞（调用者的使用问题，提供超时机制你不用，不能怪设计者）
+// Case 2:
+//  queue = {10, 5},
+//   A. 与Case1.A相同
+//   B. g1, g2, ...gX Dequeue，阻塞（在锁中，去阻塞的路上，阻塞中）
+//      1）都超时退出
+//      2）2个获取数据成功，其他超时退出
+//      3）2个获取数据成功，其他永久阻塞 —— 不需要处理，使用者不设置超时导致
+// Case 3:
+//  queue = {10, 5, 2}
+//   A. 退化为Case1.A 或者 Case2.A
+//   B. 退化为Case1.B 或者 Case2.B
+// Case 4:
+//  queue = {},
+//   A. g1 Dequeue, 阻塞（在锁中，去阻塞的路上，阻塞中）；g2，Enqueue(X)成功，通知g1，g1获取数据X成功！
+//   B. g1,g2 Dequeue, 阻塞（在锁中，去阻塞的路上，阻塞中）；g3，Enqueue(Y)成功，通知g1或g2，
+//      1）都因超时而退出
+//      2）一个获取数据Y成功，另一个超时退出
+//      3) 一个获取数据Y成功，另一个阻塞直到下一次Enqueue(Z),退化为Case4.A情况
+//         要考虑队列内部状态，比如通知信号队列中是空/满等,最好使用使用固定长度的队列，这样信号队列的容量可以为capacity
+//  C. g1, g2 Dequeue，阻塞（在锁中，去阻塞的路上，阻塞中）；g3 Dequeue 阻塞； g4，Enqueue(10, 12, 15)成功发送"1次"通知给g1/g2/g3，
+//     0) bug:有一个协程被唤醒，去Peek，在select的ticker和ctx.Done()阻塞时，可能因ctx.Done()退出，而导致无法将队头元素按时取出
+//        解决方法：采取异步通知go func(){}，唤醒全部等待在Dequeue上的协程数（考虑信号队列的capacity来确定发送信号的数量）。
+//     1) 全都超时退出
+//        拿到信号了，但因再次阻塞时超时而退出，正如次才要唤醒全部等待者，一来，更新所有等待时间；二来，增大获取数据的几率；
+//     2) 全部获取数据成功
+//     3）部分获取数据成功，部分阻塞 queue = {15} 因下一个Enqueue(8)的通知，queue = {8, 15}
+//        退化称为Case2.B —— 可能触发Bug，只唤醒一个，丢失信号，需要唤醒多个或这全部，以保证协程更新阻塞时间，阻塞时间为0时即可拿到数据出队；
+//   C.  g1, g2 Dequeue，阻塞（在锁中，去阻塞的路上，阻塞中）；g3 Dequeue ，阻塞 g4，Enqueue(10, 2)成功，发送"两次"（多次）通知给g1/g2/g3，
+//       1) 全部因超时而退出
+//        拿到信号了，但因再次阻塞时超时而退出，正如次才要唤醒全部等待者，一来，更新所有等待时间；二来，增大获取数据的几率；
+//       2) 全部成功获取数据
+//       3）部分获取数据成功，部分超时退出
+//       4）部分成功获取数据，部分阻塞
+//          a. 不再有Enqueue并发调用，退化为Case2
+//          b. 还是会有Enqueue并发调用，退化为Case1.D
+
+// 本质上来说，
+
+type Int struct {
+	id       int
+	deadline time.Duration
+}
+
+func newInt(id int, expire time.Duration) *Int {
+	return &Int{id: id, deadline: time.Duration(time.Now().Add(expire).Unix())}
+}
+
+func (i *Int) Delay() time.Duration {
+	return i.deadline
+}
+
+func newDelayQueue[T queue.Delayable[T]]() *queue.DelayQueue[T] {
+	return queue.NewDelayQueue[T](func(t1 T, t2 T) int {
+		if int64(t1.Delay()) < int64(t2.Delay()) {
+			return -1
+		} else if int64(t1.Delay()) == int64(t2.Delay()) {
+			return 0
+		} else {
+			return 1
+		}
+	})
+}
+
+func TestUnixTime(t *testing.T) {
+	delay := 10 * time.Second
+	now := time.Now()
+	deadline := now.Add(delay)
+	assert.Equal(t, 10*time.Second, time.Duration(deadline.UnixNano()-now.UnixNano()))
+}


### PR DESCRIPTION

解决 #106

```
// g1  - \
// g2  - - Enqueue() -- N --> channel（多个通道） -- 1 --> enqueueProxy 协程 --
// g3  - /                                                                   \
//                                                      两个代理协程之间通过互斥锁、通道协作，详见下方说明3
// g4  - \                                                                   /
// g5  - - Dequeue() -- N --> channel（多个通道）-- 1 --> dequeueProxy 协程 --
// g6  - /
//
// 说明：
//    1. g1、g2、g3并发调用Enqueue方法，Enqueue方法内部启动一个代理协程 enqueueProxy，
//       - enqueueProxy 职责
//         - 从调用者协程们接收数据
//         - 与下方 dequeueProxy 协程并发访问底层无锁优先级队列，将收到的数据入队
//         - 将入队结果返回给调用者协程们
//         - 如果有高优先级元素入队，导致队头变更，向 d.wakeupSignalForDequeueProxy 发信号通知下方 dequeueProxy 协程
//         - 监听退出信号，来自最后一个调用者协程发送的退出信号
//       - g1、g2、g3 通过channel与 enqueueProxy 协程通信
//         - 调用协程们通过 d.newElementsChan 向 enqueueProxy 发送数据
//         - 调用协程们通过 d.enqueueErrorChan 从 enqueueProxy 接收错误信息
//         - 第一/最后一个调用协程通过 d.quitSignalForEnqueueProxy 和 d.continueSignalFromEnqueueProxy 启动/关闭 enqueueProxy 协程
//           非并发，g1既是第一个又是最后一个需要负责启动和关闭 enqueueProxy
//           并发下，g1负责启动 enqueueProxy，g3 负责关闭 enqueueProxy
//
//    2. g3、g4、g5并发调用Dequeue方法，Dequeue方法内部启动一个代理协程 dequeueProxy，
//       - dequeueProxy 职责
//         - 获取队头，等待其过期；
// 		- 与上方 enqueueProxy 协程并发访问底层无锁优先级队列，将过期队头出队
//         - 将出队结果返回给调用者协程们
//         - 监听唤醒信号，来自 enqueueProxy 协程，重新检查队头
//         - 监听退出信号，来自最后一个调用者协程发送的退出信号
//       - g3、g4、g5 通过channel与 DequeueProxy 协程通信
//         - 调用者协程们从 d.expiredElements 获取过期元素
//         - dequeueProxy 协程通过 d.wakeupSignalForDequeueProxy 获取通知以重新检查队头
//         - 第一/最后一个调用协程通过 d.quitSignalForDequeueProxy 和 d.continueSignalFromDequeueProxy 启动/关闭 dequeueProxy 协程
//         - Dequeue的逻辑语义是"拿到队头，等待队头超时或自己超时返回; 拿不到队头，阻塞等待直到ctx过期"
//           故Dequeue不返回延迟队列为空的错误，而是让调用者阻塞等待ctx超时；如果调用者未传递具有超时的ctx，导致永久阻塞是他自己的问题
//
//    3. enqueueProxy 与 dequeueProxy 协程之间通过互斥锁、通道来协作
//      - 用 d.mutex 并发操作底层优先级队列 d.q
//      - 用 d.wakeupSignalForDequeueProxy && d.wakeupSignalForEnqueueProxy 在队列状态变化时相互唤醒
//      - 无锁队列 d.q 上只有 enqueueProxy 与 dequeueProxy 两个协程并发访问

```

1. 优点
   - 借鉴SingleFlight思想，用`enqueueProxy`和`dequeueProxy`两个协程将内部互斥锁上的并发量从`M:N`降为`1:1`
   - 借助select + channel，将Enqueue及Dequeue上大量并发调协程的阻塞与唤醒工作委托给Go运行时处理
     - 大量Enqueue导致队头频繁改变时，只需要`enqueueProxy`通知`dequeueProxy`协程重新获取队头即可，不要频繁唤醒**所有**阻塞在Dequeue上的并发调用者
   - 借助select + ctx.Done，使Enqueue和Dequeue中ctx超时控制更加精准
     - 不会出现在互斥锁上排队过程中超时无法中断，也不用陷入两难：好不容易拿到锁，不入队/出队吧白排队了，入队/出队操作吧又严重超时
2. 不足
   - 入队元素要实现的接口设计及命名问题,当前实现要求用户实现Deadline方法返回一个time.Time的截止日期——time.Now().Add(expire)
   - 时间间隔较大的多个Enqueue/Dequeue调用被视为串行/单次调用，这时`enqueueProxy`和`dequeueProxy`协程无法被复用，当这样调用较多时会有创建/销毁代理协程的开销。
   - 可以考虑添加两个方法来显示创建/销毁`enqueueProxy`和`dequeueProxy`协程
   ```go
      // 启动/销毁代理协程
      delayQueue.Star()
      defer delayQueue.Stop()

      delayQueue.Enqueue(ctx, xx)
      delayQueue.Dequeue
      ```
