### PR TITLE
延迟队列: 修改已知问题

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -2,7 +2,7 @@
 - [atomicx: 泛型封装 atomic.Value](https://github.com/gotomicro/ekit/pull/101)
 - [queue: API 定义](https://github.com/gotomicro/ekit/pull/109)
 - [queue: 基于堆和切片的优先级队列](https://github.com/gotomicro/ekit/pull/110)
-- [queue: 延时队列](https://github.com/gotomicro/ekit/pull/111)
+- [queue: 延时队列](https://github.com/gotomicro/ekit/pull/115)
 
 # v0.0.4
 - [slice: 重构 index 和 contains 的方法，直接调用对应Func 版本](https://github.com/gotomicro/ekit/pull/87)

--- a/queue/delay_queue_test.go
+++ b/queue/delay_queue_test.go
@@ -160,7 +160,7 @@ func TestDelayQueue_Dequeue(t *testing.T) {
 		capacity := 2
 		q := NewDelayQueue[delayElem](capacity)
 
-		// 使队列出于有元素状态，元素间的截止日期有较大时间差
+		// 使队列处于有元素状态，元素间的截止日期有较大时间差
 		elem1 := delayElem{
 			val:      10001,
 			deadline: time.Now().Add(50 * time.Millisecond),
@@ -173,7 +173,7 @@ func TestDelayQueue_Dequeue(t *testing.T) {
 		}
 		require.NoError(t, q.Enqueue(context.Background(), elem2))
 
-		// 并发出队，使两个调用者协程并发地按照具有较小截止日期的元素的延迟时间进行等待
+		// 并发出队，使调用者协程并发地按照较小截止日期的元素的延迟时间进行等待
 		elemsChan := make(chan delayElem, capacity)
 		var eg errgroup.Group
 		for i := 0; i < capacity; i++ {
@@ -191,8 +191,8 @@ func TestDelayQueue_Dequeue(t *testing.T) {
 		require.Equal(t, elem1.val, ele.val)
 		require.True(t, ele.deadline.Before(time.Now()))
 
-		// 再拿出长时间的，因为并发原因两个调用者协程可能都等待具有较小截止日期的元素
-		// 防止后者未经验元素是否过期直接将其出队
+		// 再拿出长时间的，因为并发原因多个调用者协程可能都等待具有较小截止日期的元素
+		// 防止后者未验证元素是否过期而直接将其出队
 		ele = <-elemsChan
 		require.Equal(t, elem2.val, ele.val)
 		require.True(t, ele.deadline.Before(time.Now()))

--- a/queue/delay_queue_test.go
+++ b/queue/delay_queue_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestDelayQueue_Dequeue(t *testing.T) {
@@ -151,6 +152,50 @@ func TestDelayQueue_Dequeue(t *testing.T) {
 		// 没有元素了，会超时
 		_, err = q.Dequeue(ctx)
 		require.Equal(t, context.DeadlineExceeded, err)
+	})
+
+	t.Run("dequeue two elements concurrently with larger delay intervals", func(t *testing.T) {
+		t.Parallel()
+
+		capacity := 2
+		q := NewDelayQueue[delayElem](capacity)
+
+		// 使队列出于有元素状态，元素间的截止日期有较大时间差
+		elem1 := delayElem{
+			val:      10001,
+			deadline: time.Now().Add(50 * time.Millisecond),
+		}
+		require.NoError(t, q.Enqueue(context.Background(), elem1))
+
+		elem2 := delayElem{
+			val:      10002,
+			deadline: time.Now().Add(500 * time.Millisecond),
+		}
+		require.NoError(t, q.Enqueue(context.Background(), elem2))
+
+		// 并发出队，使两个调用者协程并发地按照具有较小截止日期的元素的延迟时间进行等待
+		elemsChan := make(chan delayElem, capacity)
+		var eg errgroup.Group
+		for i := 0; i < capacity; i++ {
+			eg.Go(func() error {
+				ele, err := q.Dequeue(context.Background())
+				elemsChan <- ele
+				return err
+			})
+		}
+
+		assert.NoError(t, eg.Wait())
+
+		// 一定先拿出短时间的
+		ele := <-elemsChan
+		require.Equal(t, elem1.val, ele.val)
+		require.True(t, ele.deadline.Before(time.Now()))
+
+		// 再拿出长时间的，因为并发原因两个调用者协程可能都等待具有较小截止日期的元素
+		// 防止后者未经验元素是否过期直接将其出队
+		ele = <-elemsChan
+		require.Equal(t, elem2.val, ele.val)
+		require.True(t, ele.deadline.Before(time.Now()))
 	})
 }
 


### PR DESCRIPTION
当前延迟队列有如下问题:

1. 修复CHANGELOG链接(已修复)
2. 添加测试用例修复bug(已修复)
    - 当前修复方法,在<-timer.C case 中出队前验证队头元素是否过期.
    - 其他方法,去掉<-timer.C case 中的所有代码,让所有人再次去检测一次队头,可能造成不公平,恰巧有新协程调用dequeue直接将队头出队了,其他人白白等待.
3. 可读性问题
   - 在broadcast和SignalCh可见性不一致(已修复)
   - 在broadcast和SignalCh中暗中解锁,极大影响Dequeue和Enqueue的可读性.推荐标准库sync.Cond中的做法,解锁后再加锁,这样调用的地方也会有解锁步骤,可读性更好.
 

Signed-off-by: longyue0521 <longyueli0521@gmail.com>