### PR TITLE
queue: 基于semaphore的并发阻塞队列实现

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -1,4 +1,5 @@
 # 开发中
+- [queue: 基于semaphore的并发阻塞队列实现](https://github.com/gotomicro/ekit/pull/129)
 
 # v0.0.5
 - [atomicx: 泛型封装 atomic.Value](https://github.com/gotomicro/ekit/pull/101)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/mattn/go-sqlite3 v1.14.15
 	github.com/stretchr/testify v1.7.1
-	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde
+	golang.org/x/sync v0.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde h1:ejfdSekXMDxDLbRrJMwUk6KnSLZ2McaUCVcIKM+N6jc=
-golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/queue/concurrent_array_blocking_queue.go
+++ b/queue/concurrent_array_blocking_queue.go
@@ -16,6 +16,7 @@ package queue
 
 import (
 	"context"
+	"golang.org/x/sync/semaphore"
 	"sync"
 )
 
@@ -31,8 +32,8 @@ type ConcurrentArrayBlockingQueue[T any] struct {
 	// 包含多少个元素
 	count int
 
-	notEmpty *cond
-	notFull  *cond
+	eqSema *semaphore.Weighted
+	dqSema *semaphore.Weighted
 
 	// zero 不能作为返回值返回，防止用户篡改
 	zero T
@@ -43,73 +44,94 @@ type ConcurrentArrayBlockingQueue[T any] struct {
 // capacity 必须为正数
 func NewConcurrentArrayBlockingQueue[T any](capacity int) *ConcurrentArrayBlockingQueue[T] {
 	mutex := &sync.RWMutex{}
+
+	eqSema := semaphore.NewWeighted(int64(capacity))
+	dqSema := semaphore.NewWeighted(int64(capacity))
+
+	// error暂时不处理，因为目前没办法处理，只能考虑panic掉
+	// 相当于将信号量置空
+	_ = dqSema.Acquire(context.TODO(), int64(capacity))
+
 	res := &ConcurrentArrayBlockingQueue[T]{
-		data:     make([]T, capacity),
-		mutex:    mutex,
-		notEmpty: newCond(mutex),
-		notFull:  newCond(mutex),
+		data:   make([]T, capacity),
+		mutex:  mutex,
+		eqSema: eqSema,
+		dqSema: dqSema,
 	}
 	return res
 }
 
 // Enqueue 入队
-// 注意：目前我们已经通过broadcast实现了超时控制
+// 通过sema来控制容量、超时、阻塞问题
 func (c *ConcurrentArrayBlockingQueue[T]) Enqueue(ctx context.Context, t T) error {
+
+	// 能拿到，说明队列还有空位，可以入队，拿不到则阻塞
+	err := c.eqSema.Acquire(ctx, 1)
+
+	if err != nil {
+		return err
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	// 拿到锁，先判断是否超时，防止在抢锁时已经超时
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
-	c.mutex.Lock()
-	for c.count == len(c.data) {
-		signal := c.notFull.signalCh()
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-signal:
-			// 收到信号要重新加锁
-			c.mutex.Lock()
-		}
-	}
+
 	c.data[c.tail] = t
 	c.tail++
 	c.count++
+
 	// c.tail 已经是最后一个了，重置下标
 	if c.tail == cap(c.data) {
 		c.tail = 0
 	}
-	// 这里会释放锁
-	c.notEmpty.broadcast()
+
+	// 往出队的sema放入一个元素，出队的goroutine可以拿到并出队
+	c.dqSema.Release(1)
+
 	return nil
+
 }
 
 // Dequeue 出队
-// 注意：目前我们已经通过broadcast实现了超时控制
+// 通过sema来控制容量、超时、阻塞问题
 func (c *ConcurrentArrayBlockingQueue[T]) Dequeue(ctx context.Context) (T, error) {
-	if ctx.Err() != nil {
-		var t T
-		return t, ctx.Err()
+
+	// 能拿到，说明队列有元素可以取，可以出队，拿不到则阻塞
+	err := c.dqSema.Acquire(ctx, 1)
+
+	var res T
+
+	if err != nil {
+		return res, err
 	}
+
 	c.mutex.Lock()
-	for c.count == 0 {
-		signal := c.notEmpty.signalCh()
-		select {
-		case <-ctx.Done():
-			var t T
-			return t, ctx.Err()
-		case <-signal:
-			c.mutex.Lock()
-		}
+	defer c.mutex.Unlock()
+
+	// 拿到锁，先判断是否超时，防止在抢锁时已经超时
+	if ctx.Err() != nil {
+		return res, ctx.Err()
 	}
-	val := c.data[c.head]
+
+	res = c.data[c.head]
 	// 为了释放内存，GC
 	c.data[c.head] = c.zero
-	c.count--
+
 	c.head++
-	// 重置下标
+	c.count--
 	if c.head == cap(c.data) {
 		c.head = 0
 	}
-	c.notFull.broadcast()
-	return val, nil
+
+	// 往入队的sema放入一个元素，入队的goroutine可以拿到并入队
+	c.eqSema.Release(1)
+
+	return res, nil
+
 }
 
 func (c *ConcurrentArrayBlockingQueue[T]) Len() int {

--- a/queue/concurrent_array_blocking_queue.go
+++ b/queue/concurrent_array_blocking_queue.go
@@ -78,7 +78,7 @@ func (c *ConcurrentArrayBlockingQueue[T]) Enqueue(ctx context.Context, t T) erro
 	// 拿到锁，先判断是否超时，防止在抢锁时已经超时
 	if ctx.Err() != nil {
 
-		//超时应该主动归还信号量，避免容量泄露
+		// 超时应该主动归还信号量，避免容量泄露
 		c.enqueueCap.Release(1)
 
 		return ctx.Err()
@@ -119,7 +119,7 @@ func (c *ConcurrentArrayBlockingQueue[T]) Dequeue(ctx context.Context) (T, error
 	// 拿到锁，先判断是否超时，防止在抢锁时已经超时
 	if ctx.Err() != nil {
 
-		//超时应该主动归还信号量，有元素消费不到
+		// 超时应该主动归还信号量，有元素消费不到
 		c.dequeueCap.Release(1)
 
 		return res, ctx.Err()

--- a/queue/concurrent_array_blocking_queue.go
+++ b/queue/concurrent_array_blocking_queue.go
@@ -16,8 +16,9 @@ package queue
 
 import (
 	"context"
-	"golang.org/x/sync/semaphore"
 	"sync"
+
+	"golang.org/x/sync/semaphore"
 )
 
 // ConcurrentArrayBlockingQueue 有界并发阻塞队列


### PR DESCRIPTION
-主要改造了concurrent_array_blocking_queue的实现，将原来基于cond的实现改造成基于semaphore的实现