### PR TITLE
Array deque

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -1,4 +1,6 @@
 # 开发中
+
+# v0.0.6
 - [queue: 基于semaphore的并发阻塞队列实现](https://github.com/gotomicro/ekit/pull/129)
 - [mapx: hashmap实现](https://github.com/gotomicro/ekit/pull/132)
 - [mapx: 添加 Keys 方法](https://github.com/gotomicro/ekit/pull/134)

--- a/mapx/hashmap.go
+++ b/mapx/hashmap.go
@@ -30,7 +30,10 @@ func (m *HashMap[T, ValType]) newNode(key Hashable, val ValType) *node[T, ValTyp
 }
 
 type Hashable interface {
+	// Code 返回该元素的哈希值
+	// 注意：哈希值应该尽可能的均匀以避免冲突
 	Code() uint64
+	// Equals 比较两个元素是否相等。如果返回 true，那么我们会认为两个键是一样的。
 	Equals(key any) bool
 }
 

--- a/mapx/map_example_test.go
+++ b/mapx/map_example_test.go
@@ -1,0 +1,64 @@
+// Copyright 2021 gotomicro
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mapx_test
+
+import (
+	"fmt"
+
+	"github.com/gotomicro/ekit/mapx"
+)
+
+func ExampleNewHashMap() {
+	m := mapx.NewHashMap[MockKey, int](10)
+	_ = m.Put(MockKey{}, 123)
+	val, _ := m.Get(MockKey{})
+	fmt.Println(val)
+	// Output:
+	// 123
+}
+
+type MockKey struct {
+	values []int
+}
+
+func (m MockKey) Code() uint64 {
+	res := 3
+	for _, v := range m.values {
+		res += v * 7
+	}
+	return uint64(res)
+}
+
+func (m MockKey) Equals(key any) bool {
+	k, ok := key.(MockKey)
+	if !ok {
+		return false
+	}
+	if len(k.values) != len(m.values) {
+		return false
+	}
+	if k.values == nil && m.values != nil {
+		return false
+	}
+	if k.values != nil && m.values == nil {
+		return false
+	}
+	for i, v := range m.values {
+		if v != k.values[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/mapx/treemap_example_test.go
+++ b/mapx/treemap_example_test.go
@@ -1,0 +1,31 @@
+// Copyright 2021 gotomicro
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mapx_test
+
+import (
+	"fmt"
+
+	"github.com/gotomicro/ekit"
+	"github.com/gotomicro/ekit/mapx"
+)
+
+func ExampleNewTreeMap() {
+	m, _ := mapx.NewTreeMap[int, int](ekit.ComparatorRealNumber[int])
+	_ = m.Put(1, 11)
+	val, _ := m.Get(1)
+	fmt.Println(val)
+	// Output:
+	// 11
+}

--- a/stack/array_deque.go
+++ b/stack/array_deque.go
@@ -44,11 +44,14 @@ func NewArrayDequeOf[T any](elements ...T) *ArrayDeque[T] {
 }
 
 // ArrayDeque 基于切片实现的可扩容循环队列。
-//  相较于SDK中的list.List, ArrayDeque无需维护复杂的链表关系，并且基于切片的随机访问，可以快速获取数据
-// 	1.此循环队列不是无限制添加的，容量限定范围为[1 << 4, 1 << 30]
-// 	2.此循环队列不是线程安全的，它不支持多线程的并发访问
-// 	3.实现了Queue和Stack接口，你可以将他作为栈或者队列使用
-//  4.
+//  1.相较于SDK中的list.List, ArrayDeque无需维护复杂的链表关系
+//  2.相较于SDK中的list.List, 基于切片的随机访问，可以快速获取数据
+//  3.相较于SDK中的list.List, 基于切片的连续性，可以降低内存的碎片化
+// 	4.此循环队列不是无限制添加的，容量限定范围为[1 << 4, 1 << 30]
+// 	5.此循环队列不是线程安全的，它不支持多线程的并发访问
+// 	6.实现了Queue和Stack接口，你可以将他作为栈或者队列使用
+//  7.ArrayDeque没有对空值作限制，但是不推荐向其中写入nil
+//  8.ArrayDeque具有扩容机制，并且容量始终为2的幂，这造成了内存空间的浪费，在使用前可以预估容量，减少扩容导致的内存浪费
 type ArrayDeque[T any] struct {
 	elements   []T
 	head, tail int

--- a/stack/array_deque.go
+++ b/stack/array_deque.go
@@ -1,0 +1,221 @@
+package stack
+
+import (
+	"errors"
+	"math"
+)
+
+const (
+	minCapacity uint32 = 16
+	maxCapacity uint32 = math.MaxInt32 - 8
+)
+
+var (
+	ErrOutOfCapacity = errors.New("ekit: 超出最大容量限制")
+	ErrEmpty         = errors.New("ekit: deque 为空")
+)
+
+var (
+	_ Stack[any] = &ArrayDeque[any]{}
+	_ Queue[any] = &ArrayDeque[any]{}
+)
+
+// NewArrayDeque 构造一个最小容量的Deque
+func NewArrayDeque[T any]() *ArrayDeque[T] {
+	return NewArrayDequeWithCap[T](minCapacity)
+}
+
+// NewArrayDequeWithCap 构造一个指定容量的Deque
+func NewArrayDequeWithCap[T any](minCap uint32) *ArrayDeque[T] {
+	capp := calculateCap(minCap)
+	return &ArrayDeque[T]{
+		elements: make([]T, capp, capp),
+		head:     0,
+		tail:     0,
+	}
+}
+
+type ArrayDeque[T any] struct {
+	elements   []T
+	head, tail uint32
+	empty      T
+}
+
+func (a *ArrayDeque[T]) Enqueue(t T) error {
+	return a.AddLast(t)
+}
+
+func (a *ArrayDeque[T]) Dequeue() (T, error) {
+	return a.RemoveFirst()
+}
+
+func (a *ArrayDeque[T]) PeekFirst() (T, error) {
+	return a.GetFirst()
+}
+
+func (a *ArrayDeque[T]) Push(t T) error {
+	return a.AddLast(t)
+}
+
+func (a *ArrayDeque[T]) Pop() (T, error) {
+	return a.RemoveLast()
+}
+
+func (a *ArrayDeque[T]) Peek() (T, error) {
+	return a.GetLast()
+}
+
+func (a *ArrayDeque[T]) AddLast(t T) error {
+	a.elements[a.tail] = t
+	a.tail = (a.tail + 1) & (a.capacity() - 1)
+	if a.tail == a.head {
+		err := a.growDouble()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveLast 因为泛型不支持设置为nil, 所以使用trim方法在合适的时机缩容，但是还是存在内存释放不够及时的问题，可能存在内存泄露的隐患
+func (a *ArrayDeque[T]) RemoveLast() (T, error) {
+	defer func() {
+		a.trim()
+	}()
+	var result T
+	if a.IsEmpty() {
+		return result, ErrEmpty
+	}
+	t := (a.tail - 1) & (a.capacity() - 1)
+	result = a.elements[t]
+	a.elements[t] = a.empty
+	a.tail = t
+	return result, nil
+}
+
+func (a *ArrayDeque[T]) AddFirst(t T) error {
+	a.elements[a.head] = t
+	a.head = (a.head + 1) & (a.capacity() - 1)
+	if a.head == a.tail {
+		err := a.growDouble()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveFirst 因为不支持设置nil, 所以trim方法在合适的时机缩容，但是还是存在内存释放不够及时的问题，可能存在内存泄漏的隐患
+func (a *ArrayDeque[T]) RemoveFirst() (T, error) {
+	defer func() {
+		a.trim()
+	}()
+	var result T
+	if a.IsEmpty() {
+		return result, ErrEmpty
+	}
+	h := a.head
+	result = a.elements[h]
+	a.elements[h] = a.empty
+	a.head = (h + 1) & (a.capacity() - 1)
+	return result, nil
+}
+
+func (a *ArrayDeque[T]) GetFirst() (T, error) {
+	var result T
+	if a.IsEmpty() {
+		return result, ErrEmpty
+	}
+	result = a.elements[a.head]
+	return result, nil
+}
+
+func (a *ArrayDeque[T]) GetLast() (T, error) {
+	var result T
+	if a.IsEmpty() {
+		return result, ErrEmpty
+	}
+	t := (a.tail - 1) & (a.capacity() - 1)
+	result = a.elements[t]
+	return result, nil
+}
+
+func (a *ArrayDeque[T]) Len() uint32 {
+	return (a.tail - a.head) & (a.capacity() - 1)
+}
+
+func (a *ArrayDeque[T]) IsEmpty() bool {
+	return a.Len() == 0
+}
+
+// capacity , return capacity of the deque
+func (a *ArrayDeque[T]) capacity() uint32 {
+	return uint32(cap(a.elements))
+}
+
+// growDouble , grow deque capacity
+func (a *ArrayDeque[T]) growDouble() error {
+	p := a.head
+	n := a.capacity()
+	r := n - p
+	newCap := n << 1
+	if newCap > maxCapacity {
+		return ErrOutOfCapacity
+	}
+	newElements := make([]T, newCap, newCap)
+	copyArr(a.elements, p, newElements, 0, r)
+	copyArr(a.elements, 0, newElements, r, p)
+	a.elements = newElements
+	a.head = 0
+	a.tail = n
+	return nil
+}
+
+func (a *ArrayDeque[T]) trim() {
+	if a.IsEmpty() {
+		return
+	}
+	curLen := a.Len()
+	if curLen <= minCapacity {
+		return
+	}
+	expectedCapp := calculateCap(curLen)
+	if expectedCapp == a.capacity() {
+		return
+	}
+	p := a.head
+	n := curLen
+	r := n - p
+	newElement := make([]T, expectedCapp, expectedCapp)
+	copyArr(a.elements, p, newElement, 0, r)
+	copyArr(a.elements, 0, newElement, r, p)
+	a.elements = newElement
+	a.head = 0
+	a.tail = n
+}
+
+// calculateCap , calculate init capacity
+func calculateCap(capacity uint32) uint32 {
+	initialCapacity := minCapacity
+	if capacity >= initialCapacity {
+		initialCapacity = capacity
+		initialCapacity |= initialCapacity >> 1
+		initialCapacity |= initialCapacity >> 2
+		initialCapacity |= initialCapacity >> 4
+		initialCapacity |= initialCapacity >> 8
+		initialCapacity |= initialCapacity >> 16
+		initialCapacity++
+		if initialCapacity > maxCapacity {
+			initialCapacity = maxCapacity
+		}
+	}
+	return initialCapacity
+}
+
+// copyArr , copy slice
+func copyArr[T any](src []T, srcPos uint32, dest []T, destPos uint32, length uint32) {
+	for i := srcPos; i < length+srcPos; i++ {
+		dest[destPos] = src[i]
+		destPos++
+	}
+}

--- a/stack/array_deque_test.go
+++ b/stack/array_deque_test.go
@@ -3,119 +3,508 @@ package stack
 import (
 	"container/list"
 	"github.com/stretchr/testify/assert"
+	"math/rand"
 	"testing"
 )
 
-type person struct {
-	name string
-	age  int
+func TestArrayDeque_AddLast(t *testing.T) {
+	testClasses := []struct {
+		name    string
+		deque   *ArrayDeque[int]
+		loopNum int
+		wantErr error
+		wantLen int
+	}{
+		{
+			name:    "向尾部添加，并对比元素数量",
+			deque:   NewArrayDeque[int](),
+			loopNum: 1 << 16,
+			wantLen: 1 << 16,
+		},
+		{
+			name:    "向末尾添加，直到达到队列的最大容量",
+			deque:   NewArrayDequeWithCap[int](1 << 29),
+			loopNum: (1 << 29) - 1,
+			wantErr: ErrOutOfCapacity,
+			wantLen: (1 << 29) - 1,
+		},
+	}
+	for _, tc := range testClasses {
+		t.Run(tc.name, func(t *testing.T) {
+			for i := 0; i < tc.loopNum; i++ {
+				err := tc.deque.AddLast(i)
+				if err != nil {
+					t.Logf("error: %v", err)
+					assert.Equal(t, tc.wantErr, err)
+					break
+				}
+			}
+			assert.Equal(t, tc.wantLen, tc.deque.Len())
+		})
+	}
 }
 
-func TestArrayDeque_Push1(t *testing.T) {
+func TestArrayDeque_AddFirst(t *testing.T) {
+	testClasses := []struct {
+		name    string
+		deque   *ArrayDeque[int]
+		loopNum int
+		wantErr error
+		wantLen int
+	}{
+		{
+			name:    "向头部添加，并对比元素数量",
+			deque:   NewArrayDeque[int](),
+			loopNum: 1 << 16,
+			wantLen: 1 << 16,
+		},
+		{
+			name:    "向头部添加，直到达到队列的最大容量",
+			deque:   NewArrayDequeWithCap[int](1 << 29),
+			loopNum: (1 << 29) - 1,
+			wantErr: ErrOutOfCapacity,
+			wantLen: (1 << 29) - 1,
+		},
+	}
+	for _, tc := range testClasses {
+		t.Run(tc.name, func(t *testing.T) {
+			for i := 0; i < tc.loopNum; i++ {
+				err := tc.deque.AddFirst(i)
+				if err != nil {
+					assert.Equal(t, tc.wantErr, err)
+					break
+				}
+			}
+			assert.Equal(t, tc.wantLen, tc.deque.Len())
+		})
+	}
+}
+
+func TestArrayDeque_GetFirst(t *testing.T) {
+	testClass := []struct {
+		name    string
+		deque   *ArrayDeque[int]
+		newVal  int
+		wantErr error
+	}{
+		{
+			name:    "get first where deque is empty",
+			deque:   NewArrayDeque[int](),
+			wantErr: ErrEmpty,
+		},
+		{
+			name:    "get first where deque not empty",
+			deque:   NewArrayDeque[int](),
+			newVal:  100,
+			wantErr: nil,
+		},
+	}
+	for _, tc := range testClass {
+		val := tc.newVal
+		if val != 0 {
+			err := tc.deque.AddLast(val)
+			assert.Nil(t, err)
+		}
+		first, err := tc.deque.GetFirst()
+		if err != nil {
+			assert.Equal(t, tc.wantErr, err)
+		} else {
+			assert.Equal(t, first, tc.newVal)
+		}
+	}
+}
+
+func TestArrayDeque_GetLast(t *testing.T) {
+	testClass := []struct {
+		name    string
+		deque   *ArrayDeque[int]
+		newVal  int
+		wantErr error
+	}{
+		{
+			name:    "get first where deque is empty",
+			deque:   NewArrayDeque[int](),
+			wantErr: ErrEmpty,
+		},
+		{
+			name:    "get first where deque not empty",
+			deque:   NewArrayDeque[int](),
+			newVal:  100,
+			wantErr: nil,
+		},
+	}
+	for _, tc := range testClass {
+		val := tc.newVal
+		if val != 0 {
+			err := tc.deque.AddFirst(val)
+			assert.Nil(t, err)
+		}
+		first, err := tc.deque.GetLast()
+		if err != nil {
+			assert.Equal(t, tc.wantErr, err)
+		} else {
+			assert.Equal(t, first, tc.newVal)
+		}
+	}
+}
+
+func TestArrayDeque_RemoveFirst(t *testing.T) {
+	testClasses := []struct {
+		name     string
+		deque    *ArrayDeque[int]
+		wantErr  error
+		newValue int
+	}{
+		{
+			name:    "remove first where deque is empty",
+			deque:   NewArrayDeque[int](),
+			wantErr: ErrEmpty,
+		},
+		{
+			name:     "remove a value",
+			deque:    NewArrayDeque[int](),
+			wantErr:  nil,
+			newValue: 1,
+		},
+	}
+	for _, tc := range testClasses {
+		value := tc.newValue
+		if value != 0 {
+			err := tc.deque.AddLast(tc.newValue)
+			assert.Nil(t, err)
+		}
+		first, err := tc.deque.RemoveFirst()
+		if err != nil {
+			assert.Equal(t, tc.wantErr, err)
+			assert.True(t, tc.deque.IsEmpty())
+		} else {
+			assert.Equal(t, first, tc.newValue)
+		}
+	}
+}
+
+func TestArrayDeque_RemoveLast(t *testing.T) {
+	testClasses := []struct {
+		name     string
+		deque    *ArrayDeque[int]
+		wantErr  error
+		newValue int
+	}{
+		{
+			name:    "remove last where deque is empty",
+			deque:   NewArrayDeque[int](),
+			wantErr: ErrEmpty,
+		},
+		{
+			name:     "remove a value",
+			deque:    NewArrayDeque[int](),
+			wantErr:  nil,
+			newValue: 1,
+		},
+	}
+	for _, tc := range testClasses {
+		value := tc.newValue
+		if value != 0 {
+			err := tc.deque.AddFirst(tc.newValue)
+			assert.Nil(t, err)
+		}
+		first, err := tc.deque.RemoveLast()
+		if err != nil {
+			assert.Equal(t, tc.wantErr, err)
+			assert.True(t, tc.deque.IsEmpty())
+		} else {
+			assert.Equal(t, first, tc.newValue)
+		}
+	}
+}
+
+func TestArrayDeque_AsStack(t *testing.T) {
+	testClasses := []struct {
+		name         string
+		deque        *ArrayDeque[int]
+		compareStack *list.List
+		pushNum      int
+		wantErr      error
+	}{
+		{
+			name:         "push and pop",
+			deque:        NewArrayDeque[int](),
+			compareStack: list.New(),
+			pushNum:      10000,
+			wantErr:      nil,
+		},
+	}
+	for _, tc := range testClasses {
+		deque := tc.deque
+		stack := tc.compareStack
+		for i := 0; i < tc.pushNum; i++ {
+			err := deque.Push(i)
+			assert.Nil(t, err)
+			stack.PushBack(i)
+		}
+		for tc.deque.Len() > 0 {
+			pop, err := deque.Pop()
+			assert.Nil(t, err)
+			compare := stack.Remove(stack.Back()).(int)
+			assert.Equal(t, compare, pop)
+		}
+		assert.True(t, deque.IsEmpty())
+		assert.True(t, stack.Len() == 0)
+	}
+}
+
+func TestArrayDeque_AsQueue(t *testing.T) {
+	testClasses := []struct {
+		name         string
+		deque        *ArrayDeque[int]
+		compareStack *list.List
+		pushNum      int
+		wantErr      error
+	}{
+		{
+			name:         "push and pop",
+			deque:        NewArrayDeque[int](),
+			compareStack: list.New(),
+			pushNum:      10000,
+			wantErr:      nil,
+		},
+	}
+	for _, tc := range testClasses {
+		deque := tc.deque
+		stack := tc.compareStack
+		for i := 0; i < tc.pushNum; i++ {
+			err := deque.Enqueue(i)
+			assert.Nil(t, err)
+			stack.PushBack(i)
+		}
+		for tc.deque.Len() > 0 {
+			front, err := deque.Dequeue()
+			assert.Nil(t, err)
+			compare := stack.Remove(stack.Front()).(int)
+			assert.Equal(t, compare, front)
+		}
+		t.Logf("deque is empty: %v", deque.IsEmpty())
+		assert.True(t, deque.IsEmpty())
+		assert.True(t, stack.Len() == 0)
+	}
+}
+
+func TestArrayDeque_Cap(t *testing.T) {
+	testClasses := []struct {
+		name        string
+		deque       *ArrayDeque[int]
+		newVals     []int
+		expectedCap int
+	}{
+		{
+			name:        "test init cap",
+			deque:       NewArrayDeque[int](),
+			newVals:     make([]int, 0, 0),
+			expectedCap: 16,
+		},
+		{
+			name:        "test init with expected cap",
+			deque:       NewArrayDequeWithCap[int](20),
+			newVals:     make([]int, 0, 0),
+			expectedCap: 32,
+		},
+		{
+			name:        "test capacity grow up",
+			deque:       NewArrayDeque[int](),
+			newVals:     []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+			expectedCap: 32,
+		},
+		{
+			name:        "test init with expected cap and not grow",
+			deque:       NewArrayDequeWithCap[int](17),
+			newVals:     []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			expectedCap: 32,
+		},
+	}
+	for _, tc := range testClasses {
+		deque := tc.deque
+		for _, val := range tc.newVals {
+			err := deque.Push(val)
+			assert.Nil(t, err)
+		}
+		assert.Equal(t, tc.expectedCap, deque.Cap())
+	}
+}
+
+func TestArrayDeque_RandomOps(t *testing.T) {
+	testClasses := []struct {
+		name string
+		ops  func(arrayDeque *ArrayDeque[int], list *list.List)
+	}{
+		{
+			name: "AddLast",
+			ops: func(arrayDeque *ArrayDeque[int], list *list.List) {
+				val := rand.Int()
+				err := arrayDeque.AddLast(val)
+				if err != nil {
+					assert.Equal(t, ErrOutOfCapacity, err)
+				} else {
+					list.PushBack(val)
+				}
+			},
+		},
+		{
+			name: "GetLast",
+			ops: func(arrayDeque *ArrayDeque[int], list *list.List) {
+				last, err := arrayDeque.GetLast()
+				if err != nil {
+					assert.Equal(t, ErrEmpty, err)
+					assert.True(t, arrayDeque.IsEmpty())
+				} else {
+					val := list.Back().Value.(int)
+					assert.Equal(t, val, last)
+				}
+			},
+		},
+		{
+			name: "RemoveLast",
+			ops: func(arrayDeque *ArrayDeque[int], list *list.List) {
+				last, err := arrayDeque.RemoveLast()
+				if err != nil {
+					assert.Equal(t, ErrEmpty, err)
+					assert.True(t, arrayDeque.IsEmpty())
+				} else {
+					val := list.Remove(list.Back()).(int)
+					assert.Equal(t, val, last)
+				}
+			},
+		},
+		{
+			name: "AddFirst",
+			ops: func(arrayDeque *ArrayDeque[int], list *list.List) {
+				val := rand.Int()
+				err := arrayDeque.AddFirst(val)
+				if err != nil {
+					assert.Equal(t, ErrOutOfCapacity, err)
+				} else {
+					list.PushFront(val)
+				}
+			},
+		},
+		{
+			name: "GetFirst",
+			ops: func(arrayDeque *ArrayDeque[int], list *list.List) {
+				first, err := arrayDeque.GetFirst()
+				if err != nil {
+					assert.Equal(t, ErrEmpty, err)
+					assert.True(t, arrayDeque.IsEmpty())
+				} else {
+					val := list.Front().Value.(int)
+					assert.Equal(t, val, first)
+				}
+			},
+		},
+		{
+			name: "RemoveFirst",
+			ops: func(arrayDeque *ArrayDeque[int], list *list.List) {
+				first, err := arrayDeque.RemoveFirst()
+				if err != nil {
+					assert.Equal(t, ErrEmpty, err)
+					assert.True(t, arrayDeque.IsEmpty())
+				} else {
+					val := list.Remove(list.Front()).(int)
+					assert.Equal(t, val, first)
+				}
+			},
+		},
+		{
+			name: "IsEmpty",
+			ops: func(arrayDeque *ArrayDeque[int], list *list.List) {
+				empty := arrayDeque.IsEmpty()
+				listEmpty := list.Len() == 0
+				assert.Equal(t, empty, listEmpty)
+			},
+		},
+	}
+	NewArrayDeque[int]()
+	opsNum := 10000000
+	opsCount := len(testClasses)
 	deque := NewArrayDeque[int]()
-	err := deque.Push(1)
-	if err != nil {
-		t.Logf("err: %v", err)
-	}
-	pop, err := deque.Pop()
-	if err != nil {
-		t.Logf("err: %v", err)
-	}
-	t.Logf("pop value: %v", pop)
-}
-
-func TestArrayDeque_Push2(t *testing.T) {
-	deque := NewArrayDeque[int]()
-	for i := 0; i < 63; i++ {
-		err := deque.Push(i)
-		if err != nil {
-			t.Logf("push err: %v", err)
-		}
-	}
-	for !deque.IsEmpty() {
-		pop, err := deque.Pop()
-		if err != nil {
-			t.Logf("err: %v", err)
-		}
-		t.Logf("pop value: %v", pop)
-	}
-}
-
-func TestArrayDeque_Push3(t *testing.T) {
-	clazzList := []*person{
-		&person{"zhangsan", 1},
-		&person{"lisi", 2},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-		&person{"wangwu", 3},
-	}
-	deque := NewArrayDeque[*person]()
-	for _, val := range clazzList {
-		err := deque.Push(val)
-		if err != nil {
-			t.Logf("err: %v", err)
-		}
-	}
-	for !deque.IsEmpty() {
-		pop, err := deque.Pop()
-		if err != nil {
-			t.Logf("err: %v", err)
-		}
-		t.Logf("pop value: %v", pop)
-	}
-}
-
-func TestArrayDeque_Push(t *testing.T) {
 	stack := list.New()
+	for i := 0; i < opsNum; i++ {
+		intn := rand.Int()
+		ops := intn % opsCount
+		testClass := testClasses[ops]
+		testClass.ops(deque, stack)
+	}
+}
+
+func BenchmarkArrayDeque_RandomOps(b *testing.B) {
 	deque := NewArrayDeque[int]()
-	n := 100000
-	for i := 0; i < n; i++ {
-		stack.PushBack(i)
-		err := deque.Push(i)
-		assert.Nil(t, err, "must return nil")
+	stack := list.New()
+	b.Run("deque", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			ops := rand.Int()
+			arrayDequeRandomOps(deque, ops)
+		}
+	})
+	b.Run("stack", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			ops := rand.Int()
+			listRandomOps(stack, ops)
+		}
+	})
+}
+
+func arrayDequeRandomOps(deque *ArrayDeque[int], ops int) {
+	oprations := []func(d *ArrayDeque[int]){
+		func(d1 *ArrayDeque[int]) {
+			val := rand.Int()
+			d1.AddLast(val)
+		},
+		func(d2 *ArrayDeque[int]) {
+			d2.GetLast()
+		},
+		func(d3 *ArrayDeque[int]) {
+			d3.RemoveLast()
+		},
+		func(d4 *ArrayDeque[int]) {
+			val := rand.Int()
+			d4.AddFirst(val)
+		},
+		func(d5 *ArrayDeque[int]) {
+			d5.GetFirst()
+		},
+		func(d6 *ArrayDeque[int]) {
+			d6.RemoveFirst()
+		},
 	}
-	for stack.Len() > 0 {
-		ele1 := stack.Remove(stack.Back()).(int)
-		pop, err := deque.Pop()
-		assert.Nil(t, err, "error must be nil")
-		assert.Equal(t, ele1, pop, "")
+	idx := ops % len(oprations)
+	oprations[idx](deque)
+}
+
+func listRandomOps(stack *list.List, ops int) {
+	oprations := []func(d *list.List){
+		func(d1 *list.List) {
+			val := rand.Int()
+			d1.PushFront(val)
+		},
+		func(d2 *list.List) {
+			d2.Back()
+		},
+		func(d3 *list.List) {
+			if d3.Len() > 0 {
+				d3.Remove(d3.Back())
+			}
+		},
+		func(d4 *list.List) {
+			val := rand.Int()
+			d4.PushBack(val)
+		},
+		func(d5 *list.List) {
+			d5.Front()
+		},
+		func(d6 *list.List) {
+			if d6.Len() > 0 {
+				d6.Remove(d6.Front())
+			}
+		},
 	}
+	idx := ops % len(oprations)
+	oprations[idx](stack)
 }

--- a/stack/array_deque_test.go
+++ b/stack/array_deque_test.go
@@ -1,0 +1,121 @@
+package stack
+
+import (
+	"container/list"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type person struct {
+	name string
+	age  int
+}
+
+func TestArrayDeque_Push1(t *testing.T) {
+	deque := NewArrayDeque[int]()
+	err := deque.Push(1)
+	if err != nil {
+		t.Logf("err: %v", err)
+	}
+	pop, err := deque.Pop()
+	if err != nil {
+		t.Logf("err: %v", err)
+	}
+	t.Logf("pop value: %v", pop)
+}
+
+func TestArrayDeque_Push2(t *testing.T) {
+	deque := NewArrayDeque[int]()
+	for i := 0; i < 63; i++ {
+		err := deque.Push(i)
+		if err != nil {
+			t.Logf("push err: %v", err)
+		}
+	}
+	for !deque.IsEmpty() {
+		pop, err := deque.Pop()
+		if err != nil {
+			t.Logf("err: %v", err)
+		}
+		t.Logf("pop value: %v", pop)
+	}
+}
+
+func TestArrayDeque_Push3(t *testing.T) {
+	clazzList := []*person{
+		&person{"zhangsan", 1},
+		&person{"lisi", 2},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+		&person{"wangwu", 3},
+	}
+	deque := NewArrayDeque[*person]()
+	for _, val := range clazzList {
+		err := deque.Push(val)
+		if err != nil {
+			t.Logf("err: %v", err)
+		}
+	}
+	for !deque.IsEmpty() {
+		pop, err := deque.Pop()
+		if err != nil {
+			t.Logf("err: %v", err)
+		}
+		t.Logf("pop value: %v", pop)
+	}
+}
+
+func TestArrayDeque_Push(t *testing.T) {
+	stack := list.New()
+	deque := NewArrayDeque[int]()
+	n := 100000
+	for i := 0; i < n; i++ {
+		stack.PushBack(i)
+		err := deque.Push(i)
+		assert.Nil(t, err, "must return nil")
+	}
+	for stack.Len() > 0 {
+		ele1 := stack.Remove(stack.Back()).(int)
+		pop, err := deque.Pop()
+		assert.Nil(t, err, "error must be nil")
+		assert.Equal(t, ele1, pop, "")
+	}
+}

--- a/stack/types.go
+++ b/stack/types.go
@@ -1,0 +1,18 @@
+package stack
+
+import "github.com/gotomicro/ekit/queue"
+
+type Stack[T any] interface {
+	// Push 将元素入栈，如果无法入栈，那么返回错误
+	Push(t T) error
+	// Pop 弹出栈顶元素, 如果此时栈中没有数据，那么返回错误
+	Pop() (T, error)
+	// Peek 查看栈顶元素，但是不删除，如果栈中没有数据，那么返回错误
+	Peek() (T, error)
+}
+
+type Queue[T any] interface {
+	// PeekFirst 查看队首元素，但是不删除，如果队列中没有数据，那么返回错误
+	PeekFirst() (T, error)
+	queue.Queue[T]
+}

--- a/stack/types.go
+++ b/stack/types.go
@@ -7,12 +7,12 @@ type Stack[T any] interface {
 	Push(t T) error
 	// Pop 弹出栈顶元素, 如果此时栈中没有数据，那么返回错误
 	Pop() (T, error)
-	// Peek 查看栈顶元素，但是不删除，如果栈中没有数据，那么返回错误
-	Peek() (T, error)
+	// Top 查看栈顶元素，但是不删除，如果栈中没有数据，那么返回错误
+	Top() (T, error)
 }
 
 type Queue[T any] interface {
-	// PeekFirst 查看队首元素，但是不删除，如果队列中没有数据，那么返回错误
-	PeekFirst() (T, error)
+	// Front 查看队首元素，但是不删除，如果队列中没有数据，那么返回错误
+	Front() (T, error)
 	queue.Queue[T]
 }


### PR DESCRIPTION
基于切片实现的可扩容循环队列
1.相较于SDK中的list.List, 无需维护链表关系
2.相较于SDK中的list.List, 基于切片的随机访问，可以快速获取数据
3.相较于SDK中的list.List, 基于切片的连续性，可以降低内存的碎片化
4.此循环队列不是无限制添加的，容量限定范围为[1 << 4, 1 << 30]
5.此循环队列不是线程安全的，它不支持多线程的并发访问
6.实现了Queue和Stack接口，你可以将他作为栈或者队列使用
7.ArrayDeque没有对空值作限制，使用时应该注意nil的处理
8.ArrayDeque具有扩容机制，并且容量始终为2的幂，这造成了内存空间的浪费，在使用前可以预估容量，减少扩容导致的内存浪费